### PR TITLE
Fix for Bug #17 - Make sure the directory exists before attempting to write cookie file 

### DIFF
--- a/default.py
+++ b/default.py
@@ -814,17 +814,15 @@ def AddAvailableLiveStreamsDirectory(name, channelname, iconimage):
 
 
 def GetCookies():
+    if(not os.path.exists(DIR_USERDATA)):
+        os.makedirs(DIR_USERDATA)
     cookie_file = os.path.join(DIR_USERDATA,'iplayer.cookies')
     cj = cookielib.LWPCookieJar(cookie_file)
-
     if(os.path.exists(cookie_file)):
         try:
             cj.load(ignore_discard=True, ignore_expires=True)
         except:
             xbmcgui.Dialog().notification(translation(32000), translation(32002), xbmcgui.NOTIFICATION_ERROR)
-    else:
-        xbmcgui.Dialog().notification(translation(32000), translation(32003), xbmcgui.NOTIFICATION_ERROR)
-    
     return cj
 
 
@@ -837,9 +835,12 @@ def OpenURL(url):
         dialog = xbmcgui.Dialog()
         dialog.ok(translation(32000), "%s" % e)
         sys.exit(1)
-    for cookie in r.cookies:
-        cookies.set_cookie(cookie)
-    cookies.save(ignore_discard=True, ignore_expires=True)
+    try:
+        for cookie in r.cookies:
+            cookies.set_cookie(cookie)
+        cookies.save(ignore_discard=True, ignore_expires=True)
+    except:
+        pass
     return r.content
 
 
@@ -857,9 +858,13 @@ def OpenURLPost(url, post_data):
         dialog = xbmcgui.Dialog()
         dialog.ok(translation(32000), "%s" % e)
         sys.exit(1)
-    for cookie in r.cookies:
-        cookies.set_cookie(cookie)
-    cookies.save(ignore_discard=True, ignore_expires=True)
+    
+    try:
+        for cookie in r.cookies:
+            cookies.set_cookie(cookie)
+        cookies.save(ignore_discard=True, ignore_expires=True)
+    except:
+        pass
     return r
 
 

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -35,5 +35,4 @@
   <string id="32000">Error</string>
   <string id="32001">BBC iPlayer TV programmes are available to play in the UK only.</string>
   <string id="32002">Cookie Load Failed</string>
-  <string id="32003">Cookie No Such File</string>
 </strings>


### PR DESCRIPTION
This fixes #17 by creating the DIR_USERDATA directory if it does not already exist. This is where settings.xml, iplayer.srt, and iplayer.cookies are stored. The reason we have not been caught by this before is that when you save settings this directory gets created.

Sorry my bad, but should be all sorted now. I've tested with a clean install and also tested all the BBCiD functionality again.