### PR TITLE
last ScrapeSearchEpisodes match fails

### DIFF
--- a/default.py
+++ b/default.py
@@ -174,6 +174,9 @@ def ScrapeSearchEpisodes(url):
             re.DOTALL)
         aired = ParseAired(aired.group(1) if aired else '')
         CheckAutoplay(name, episode_url, iconimage, plot, aired=aired)
+
+    #FAIL
+    '''
     match1 = re.compile(
         'search-group"  data-ip-id="(.+?)">'
         '.+?" title="(.+?)"'
@@ -184,6 +187,8 @@ def ScrapeSearchEpisodes(url):
     for programme_id, name, iconimage, plot, group_url in match1:
         episode_url = "http://www.bbc.co.uk%s" % group_url
         ScrapeSearchEpisodes(episode_url)
+    '''
+
     nextpage = re.compile('<span class="next txt"> <a href=".+?page=(\d+)">').findall(html)
     return nextpage
 


### PR DESCRIPTION
This fixes runaway Search. There might be some need for it but it fails big time here.
See this search for Eastenders:
```
    <li class="list-item search-group"  data-ip-id="p035v4gc">
        <a
    href="http://www.bbc.co.uk/programmes/p035v4gc"
    class="list-item-link stat unavailable"
    
    data-timeliness-type="unavailable"
    data-object-type="episode-unavail"
    title="Preview">
    <div class="title top-title">Preview</div>

    <div class="primary">
            <div class="r-image"  data-ip-type="episode" data-ip-src="http://ichef.bbci.co.uk/images/ic/336x189/p035v6kt.jpg">
        <img class="img" src="http://static.bbci.co.uk/tviplayer/1.79.0/img/channels/episode_placeholder.jpg" alt="" />
        <noscript><img src="http://ichef.bbci.co.uk/images/ic/336x189/p035v6kt.jpg" alt="" class="loaded" /></noscript>
    </div>
        <div class="overlay"></div>

        <span class="signpost editorial">Not available</span>
    </div>

    <div class="secondary">
        <div class="title">Preview</div>

            <div class="subtitle">EastEnders Halloween Trailer</div>

        <p class="synopsis">There's tension and terror on the Square this Halloween.</p>

        <p>
                <span class="master-brand">BBC</span>
        </p>
    </div>

    <div class="tertiary">
        <p>For more information please visit the <span class="anchor">programme website</span>.</p>
    </div>

</a>


    </li>
```