### PR TITLE
HD TV: good news bad news

### DIFF
--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -748,24 +748,55 @@ def AddAvailableLiveStreamItem(name, channelname, iconimage):
     stream_bitrates = [9999, 300, 576, 974, 1500, 1732, 2100, 3000, 3600, 5308] 
 
     bitrate_selected = int(ADDON.getSetting('live_bitrate'))
+    supplier_selected = int(ADDON.getSetting('live_source'))
+    if  supplier_selected == 1:
+        suppliers = ['ak']
+    elif supplier_selected == 2:
+        suppliers = ['llnw']
+    else:
+        suppliers = ['ak', 'llnw']
 
     retlist = []
-    NEW_URL = "http://open.live.bbc.co.uk/mediaselector/5/select/version/2.0/mediaset/iptv-all/vpid/%s/transferformat/hls?cb=%d" % (channelname, random.randrange(10000,99999)) 
 
-    html = OpenURL(NEW_URL)
+    #for device in ['iptv-all', 'apple-ipad-hls']:
+    for device in ['iptv-all']:
+        NEW_URL = "http://open.live.bbc.co.uk/mediaselector/5/select/version/2.0/mediaset/%s/vpid/%s/transferformat/hls?cb=%d" % (device, channelname, random.randrange(10000,99999)) 
+        html = OpenURL(NEW_URL)
+        match = re.compile(
+            'media.+?bitrate="(.+?)".+?encoding="(.+?)".+?connection.+?href="(.+?)".+?supplier="(.+?)".+?transferFormat="(.+?)"'
+            ).findall(html)
+        templist = []
+        for bitrate, encoding, url, supplier, transfer_format in match:
+            templist.append((supplier, int(bitrate), url, device))
 
-    # Parse the different streams and add them as new directory entries.
-    match = re.compile(
-        'media.+?bitrate="(.+?)".+?encoding="(.+?)".+?connection.+?href="(.+?)".+?supplier="(.+?)".+?transferFormat="(.+?)"'
-        ).findall(html)
-    for bitrate, encoding, url, supplier, transfer_format in match:
-        retlist.append((supplier, int(bitrate), url, encoding))
+        templist = sorted(templist, key=itemgetter(1), reverse=True)
+        retlist.append(templist[0]) #TODO only the last bitrate is valid!!!
+
+    #for device in ['abr_hdtv', 'hls_tablet']:
+    for device in ['abr_hdtv']:
+        for supplier in suppliers:
+            NEW_URL = "http://a.files.bbci.co.uk/media/live/manifesto/audio_video/simulcast/hls/uk/%s/%s/%s.m3u8" % (device, supplier, channelname)
+            html = OpenURL(NEW_URL)
+            match = re.compile('#EXT-X-STREAM-INF:PROGRAM-ID=(.+?),BANDWIDTH=(.+?),CODECS="(.*?)",RESOLUTION=(.+?)\s*(.+?.m3u8)').findall(html)
+            for id, bandwidth, codecs, resolution, url in match:
+                bitrate = int(int(bandwidth)/1000.0)
+                retlist.append((supplier, bitrate, url, device))
 
     retlist = sorted(retlist, key=itemgetter(1,0), reverse=True)
 
-    for (supplier, bitrate, url, encoding) in retlist:
+    for (supplier, bitrate, url, extra_info) in retlist:
 
         if bitrate <= stream_bitrates[bitrate_selected]: 
+            if bitrate > 2100:
+                color = 'green'
+            elif bitrate > 1000:
+                color = 'yellow'
+            elif bitrate > 600:
+                color = 'orange'
+            else:
+                color = 'red'
+            title = name + ' - [I][COLOR %s]%0.1f Mbps[/COLOR] [COLOR white]%s[/COLOR] [COLOR grey]%s[/COLOR][/I]' % (color, bitrate/1000.0, supplier, extra_info)
+            #PlayStream(title, url, iconimage, '', '')
             PlayStream(name, url, iconimage, '', '')
 
 
@@ -779,20 +810,34 @@ def AddAvailableLiveStreamsDirectory(name, channelname, iconimage):
         channelname: determines which channel is queried.
     """
     retlist = []
-    NEW_URL = "http://open.live.bbc.co.uk/mediaselector/5/select/version/2.0/mediaset/iptv-all/vpid/%s/transferformat/hls?cb=%d" % (channelname, random.randrange(10000,99999)) 
 
-    html = OpenURL(NEW_URL)
+    #for device in ['iptv-all', 'apple-ipad-hls']:
+    for device in ['iptv-all']:
+        NEW_URL = "http://open.live.bbc.co.uk/mediaselector/5/select/version/2.0/mediaset/%s/vpid/%s/transferformat/hls?cb=%d" % (device, channelname, random.randrange(10000,99999)) 
+        html = OpenURL(NEW_URL)
+        match = re.compile(
+            'media.+?bitrate="(.+?)".+?encoding="(.+?)".+?connection.+?href="(.+?)".+?supplier="(.+?)".+?transferFormat="(.+?)"'
+            ).findall(html)
+        templist = []
+        for bitrate, encoding, url, supplier, transfer_format in match:
+            templist.append((supplier, int(bitrate), url, device))
 
-    # Parse the different streams and add them as new directory entries.
-    match = re.compile(
-        'media.+?bitrate="(.+?)".+?encoding="(.+?)".+?connection.+?href="(.+?)".+?supplier="(.+?)".+?transferFormat="(.+?)"'
-        ).findall(html)
-    for bitrate, encoding, url, supplier, transfer_format in match:
-        retlist.append((supplier, int(bitrate), url, encoding))
+        templist = sorted(templist, key=itemgetter(1), reverse=True)
+        retlist.append(templist[0]) #TODO only the last bitrate is valid!!!
+
+    #for device in ['abr_hdtv', 'hls_tablet']:
+    for device in ['abr_hdtv']:
+        for supplier in ['ak', 'llnw']:
+            NEW_URL = "http://a.files.bbci.co.uk/media/live/manifesto/audio_video/simulcast/hls/uk/%s/%s/%s.m3u8" % (device, supplier, channelname)
+            html = OpenURL(NEW_URL)
+            match = re.compile('#EXT-X-STREAM-INF:PROGRAM-ID=(.+?),BANDWIDTH=(.+?),CODECS="(.*?)",RESOLUTION=(.+?)\s*(.+?.m3u8)').findall(html)
+            for id, bandwidth, codecs, resolution, url in match:
+                bitrate = int(int(bandwidth)/1000.0)
+                retlist.append((supplier, bitrate, url, device))
 
     retlist = sorted(retlist, key=itemgetter(1,0), reverse=True)
 
-    for (supplier, bitrate, url, encoding) in retlist:
+    for (supplier, bitrate, url, device) in retlist:
 
         if bitrate > 2100:
             color = 'green'
@@ -802,6 +847,7 @@ def AddAvailableLiveStreamsDirectory(name, channelname, iconimage):
             color = 'orange'
         else:
             color = 'red'
+        #title = name + ' - [I][COLOR %s]%0.1f Mbps[/COLOR] [COLOR white]%s[/COLOR] [COLOR grey]%s[/COLOR][/I]' % (color, bitrate/1000.0, supplier, device)
         title = name + ' - [I][COLOR %s]%0.1f Mbps[/COLOR] [COLOR white]%s[/COLOR][/I]' % (color, bitrate/1000.0, supplier)
         AddMenuEntry(title, url, 201, iconimage, '', '')
 


### PR DESCRIPTION
Good News: I found some non magic number streams with even better HD bitrate.
Bad News: They don't work for regional and local channels.
Bad News 2: The ones in 2.1.1 only provide the highest bitrate streams. The lower bitrates point to the same url! This could be a problem for low bandwidth users. I didn't pick up on it because all the streams played. It must be part of an automatic bitrate selection but I don't know if Kodi will honour it.

Everything seems to work with this version but there are lots of options for bitrates, suppliers and devices that are going to need consolidating later.
