### PR TITLE
live streams without magic numbers

### DIFF
--- a/default.py
+++ b/default.py
@@ -161,7 +161,7 @@ elif mode == 122:
     Video.GetAvailableStreams(name, url, iconimage, description)
 
 elif mode == 123:
-    Video.AddAvailableLiveStreamsDirectory(name, url, iconimage)
+    Video.AddAvailableLiveStreams(name, url, iconimage)
 
 elif mode == 124:
     Video.GetAtoZPage(url)
@@ -195,10 +195,10 @@ elif mode == 201:
     Video.PlayStream(name, url, iconimage, description, subtitles_url)
 
 elif mode == 202:
-    Video.AddAvailableStreamItem(name, url, iconimage, description)
+    Video.AddAvailableStreams(name, url, iconimage, description)
 
 elif mode == 203:
-    Video.AddAvailableLiveStreamItem(name, url, iconimage)
+    Video.AddAvailableLiveStreams(name, url, iconimage)
 
 elif mode == 211:
     Radio.PlayStream(name, url, iconimage, description, subtitles_url)

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -780,8 +780,8 @@ def AddAvailableLiveStreams(name, channelname, iconimage):
                 ).findall(html)
             playlist_urls = set()
             for bitrate, encoding, url, supplier, transfer_format in match:
-                playlist_urls.add(url)
-            for playlist_url in playlist_urls:
+                playlist_urls.add((supplier, url))
+            for (supplier, playlist_url) in playlist_urls:
                 html = OpenURL(playlist_url)
                 match = re.compile('#EXT-X-STREAM-INF:PROGRAM-ID=(.+?),BANDWIDTH=(.+?),CODECS="(.*?)",RESOLUTION=(.+?)\s*(.+?.m3u8)').findall(html)
                 for id, bandwidth, codecs, resolution, url in match:

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -763,7 +763,7 @@ def AddAvailableLiveStreams(name, channelname, iconimage):
     stream_set = set()
 
     for device in ['abr_hdtv', 'hls_tablet']:
-        for supplier in ['ak', 'llnw']:
+        for supplier in suppliers:
             playlist_url = "http://a.files.bbci.co.uk/media/live/manifesto/audio_video/simulcast/hls/uk/%s/%s/%s.m3u8" % (device, supplier, channelname)
             html = OpenURL(playlist_url)
             match = re.compile('#EXT-X-STREAM-INF:PROGRAM-ID=(.+?),BANDWIDTH=(.+?),CODECS="(.*?)",RESOLUTION=(.+?)\s*(.+?.m3u8)').findall(html)
@@ -786,6 +786,7 @@ def AddAvailableLiveStreams(name, channelname, iconimage):
                 match = re.compile('#EXT-X-STREAM-INF:PROGRAM-ID=(.+?),BANDWIDTH=(.+?),CODECS="(.*?)",RESOLUTION=(.+?)\s*(.+?.m3u8)').findall(html)
                 for id, bandwidth, codecs, resolution, url in match:
                     bitrate = int(int(bandwidth)/1000.0)
+                    #NOTE: Don't filter out these suppliers. This is a fallback option if no streams are found above.
                     if supplier == 'akamai_hls_live':
                         supplier = 'ak'
                     stream_set.add((supplier, bitrate, url))

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -762,8 +762,7 @@ def AddAvailableLiveStreams(name, channelname, iconimage):
 
     stream_list = []
 
-    #for device in ['abr_hdtv', 'hls_tablet']:
-    for device in ['abr_hdtv']:
+    for device in ['abr_hdtv', 'hls_tablet']:
         for supplier in ['ak', 'llnw']:
             NEW_URL = "http://a.files.bbci.co.uk/media/live/manifesto/audio_video/simulcast/hls/uk/%s/%s/%s.m3u8" % (device, supplier, channelname)
             html = OpenURL(NEW_URL)
@@ -773,8 +772,7 @@ def AddAvailableLiveStreams(name, channelname, iconimage):
                 stream_list.append((supplier, bitrate, url, device))
 
     if not stream_list:
-        #for device in ['iptv-all', 'apple-ipad-hls']:
-        for device in ['iptv-all']:
+        for device in ['iptv-all', 'apple-ipad-hls']:
             NEW_URL = "http://open.live.bbc.co.uk/mediaselector/5/select/version/2.0/mediaset/%s/vpid/%s/transferformat/hls?cb=%d" % (device, channelname, random.randrange(10000,99999)) 
             html = OpenURL(NEW_URL)
             match = re.compile(
@@ -791,7 +789,7 @@ def AddAvailableLiveStreams(name, channelname, iconimage):
                     bitrate = int(int(bandwidth)/1000.0)
                     stream_list.append((supplier, bitrate, url, device))
 
-    stream_list = sorted(stream_list, key=itemgetter(1,0), reverse=True)
+    stream_list = sorted(stream_list, key=itemgetter(1,0,3), reverse=True)
 
     for (supplier, bitrate, url, device) in stream_list:
         if autoplay == 'true':
@@ -810,8 +808,7 @@ def AddAvailableLiveStreams(name, channelname, iconimage):
                 supplier = 'Akamai'
             elif supplier == 'llnw':
                 supplier = 'Limelight'
-            #title = name + ' - [I][COLOR %s]%0.1f Mbps[/COLOR] [COLOR white]%s[/COLOR] [COLOR grey]%s[/COLOR][/I]' % (color, bitrate/1000.0, supplier, device)
-            title = name + ' - [I][COLOR %s]%0.1f Mbps[/COLOR] [COLOR white]%s[/COLOR][/I]' % (color, bitrate/1000.0, supplier)
+            title = name + ' - [I][COLOR %s]%0.1f Mbps[/COLOR] [COLOR white]%s[/COLOR] [COLOR grey]%s[/COLOR][/I]' % (color, bitrate/1000.0, supplier, device)
             AddMenuEntry(title, url, 201, iconimage, '', '')
 
 


### PR DESCRIPTION
This should find HD and SD streams without having to use the magic numbers. They are still there as a fallback if no other streams are found.

I am pretty confident this picks the right streams with the correct bitrates but you should check if you can.