### PR TITLE
filter providers by catchup_source

### DIFF
--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -1111,16 +1111,19 @@ def ParseStreams(stream_id):
     match = re.compile(
         'connection authExpires=".+?href="(.+?)".+?supplier="mf_(.+?)".+?transferFormat="(.+?)"'
         ).findall(html)
+    source = int(ADDON.getSetting('catchup_source'))
     for m3u8_url, supplier, transfer_format in match:
         tmp_sup = 0
         tmp_br = 0
         if transfer_format == 'hls':
-            if supplier == 'akamai_uk_hls':
+            if supplier == 'akamai_uk_hls' and source in [0,1]:
                 tmp_sup = 1
-            elif supplier == 'limelight_uk_hls':
+            elif supplier == 'limelight_uk_hls' and source in [0,2]:
                 tmp_sup = 2
-            elif supplier == 'bidi_uk_hls':
+            elif supplier == 'bidi_uk_hls' and source in [0,3]:
                 tmp_sup = 3
+            else:
+                continue
             m3u8_breakdown = re.compile('(.+?)iptv.+?m3u8(.+?)$').findall(m3u8_url)
             #print m3u8_breakdown
             # print m3u8_url
@@ -1153,10 +1156,12 @@ def ParseStreams(stream_id):
         tmp_sup = 0
         tmp_br = 0
         if transfer_format == 'hls':
-            if supplier == 'akamai_hls_open':
+            if supplier == 'akamai_hls_open' and source in [0,1]:
                 tmp_sup = 1
-            elif supplier == 'limelight_hls_open':
+            elif supplier == 'limelight_hls_open' and source in [0,2]:
                 tmp_sup = 2
+            else:
+                continue
             m3u8_breakdown = re.compile('.+?master.m3u8(.+?)$').findall(m3u8_url)
         # print m3u8_url
         # print m3u8_breakdown

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -43,7 +43,7 @@
     <setting label="30103" type="lsep"  />
     <setting id="streams_autoplay" label="30205" type="bool" default="true" />
     <setting label="30101" type="lsep"  />
-    <setting id="catchup_source" label="30210" type="enum" values="Any|Akamai|Limelight|Bidi" default="0" enable="eq(-2,true)" />
+    <setting id="catchup_source" label="30210" type="enum" values="Any|Akamai|Limelight|Bidi" default="0" enable="true" />
     <setting id="catchup_bitrate" label="30211" type="enum" values="Highest|0.8 Mbps|1.0 Mbps|1.5 Mbps|1.8 Mbps|2.4 Mbps|3.1 Mbps|5.5 Mbps" default="0" enable="eq(-3,true)" />
     <setting id="live_source" label="30220" type="enum" values="Any|Akamai|Limelight" default="0" enable="eq(-4,true)" />
     <setting id="live_bitrate" label="30230" type="enum" values="Highest|0.1 Mbps|0.2 Mbps|0.3 Mbps|0.6 Mbps|1.0 Mbps|1.8 Mbps|3.1 Mbps|5.5 Mbps" default="0" enable="eq(-5,true)" />


### PR DESCRIPTION
This pre-filters the providers in ParseStreams. It should be a fair bit quicker to switch programs now too on my kid's rpi v1. ;) There is no need for notifications now.