### PR TITLE
remove necessity to have inputstream.adaptive

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -3,7 +3,6 @@
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
     <import addon="script.module.requests" version="2.7.0"/>
-    <import addon="inputstream.adaptive" version="1.0.6"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="default.py">
         <provides>audio video</provides>

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -1153,7 +1153,8 @@ def Search(search_entered):
 
 
 def AddAvailableLiveStreamItemSelector(name, channelname, iconimage):
-    if ((int(ADDON.getSetting('stream_protocol')) == 1) or
+    if (not xbmc.getCondVisibility("System.HasAddon(inputstream.adaptive)") or
+        (int(ADDON.getSetting('stream_protocol')) == 1) or
         (channelname.startswith('sport_stream_'))):
         return AddAvailableLiveStreamItem(name, channelname, iconimage)
     elif int(ADDON.getSetting('stream_protocol')) == 0:
@@ -1222,7 +1223,8 @@ def AddAvailableLiveStreamsDirectory(name, channelname, iconimage):
         iconimage: only used for displaying the channel.
         channelname: determines which channel is queried.
     """
-    if ((int(ADDON.getSetting('stream_protocol')) == 1) or
+    if (not xbmc.getCondVisibility("System.HasAddon(inputstream.adaptive)") or
+        (int(ADDON.getSetting('stream_protocol')) == 1) or
         (channelname.startswith('sport_stream_'))):
         streams = ParseLiveStreams(channelname, '')
 
@@ -1296,7 +1298,7 @@ def PlayStream(name, url, iconimage, description, subtitles_url):
     liz.setInfo(type='Video', infoLabels={'Title': name})
     liz.setProperty("IsPlayable", "true")
     liz.setPath(url)
-    if ADDON.getSetting('stream_protocol') == '0':
+    if xbmc.getCondVisibility("System.HasAddon(inputstream.adaptive)") and (ADDON.getSetting('stream_protocol') == '0'):
         liz.setProperty('inputstreamaddon', 'inputstream.adaptive')
         liz.setProperty('inputstream.adaptive.manifest_type', 'mpd')
     if subtitles_url and ADDON.getSetting('subtitles') == 'true':
@@ -1334,7 +1336,7 @@ def AddAvailableStreamsDirectory(name, stream_id, iconimage, description):
             color = 'ffffff00'
         else:
             color = 'ffffa500'
-        if int(ADDON.getSetting('stream_protocol')) == 1:
+        if not xbmc.getCondVisibility("System.HasAddon(inputstream.adaptive)")  or (ADDON.getSetting('stream_protocol') == '1'):
             title = name + ' - [I][COLOR %s]%0.1f Mbps[/COLOR] [COLOR ffd3d3d3]%s[/COLOR][/I]' % (
                 color, bitrates[bitrate] / 1000, suppliers[supplier])
         else:
@@ -1343,7 +1345,7 @@ def AddAvailableStreamsDirectory(name, stream_id, iconimage, description):
 
 
 def ParseStreamsHLSDASH(stream_id):
-    if int(ADDON.getSetting('stream_protocol')) == 1:
+    if not xbmc.getCondVisibility("System.HasAddon(inputstream.adaptive)") or ADDON.getSetting('stream_protocol') == '1':
         return ParseStreams(stream_id)
     elif int(ADDON.getSetting('stream_protocol')) == 0:
         return ParseDASHStreams(stream_id)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -43,7 +43,7 @@
     <setting label="30103" type="lsep"  />
     <setting id="streams_autoplay" label="30205" type="bool" default="true" />
     <setting label="30101" type="lsep"  />
-    <setting id="stream_protocol" label="30212" type="enum" values="DASH|HLS" default="0" />
+    <setting id="stream_protocol" label="30212" type="enum" values="DASH|HLS" default="0" visible="System.HasAddon(inputstream.adaptive)"/>
     <setting id="catchup_source" label="30210" type="enum" values="Any|Akamai|Limelight|Bidi" default="0" enable="true" />
     <setting id="catchup_bitrate" label="30211" type="enum" values="Highest|0.8 Mbps|1.0 Mbps|1.5 Mbps|1.8 Mbps|2.4 Mbps|3.1 Mbps|5.5 Mbps" default="0" enable="eq(-4,true) + eq(-2,1)" />
     <setting id="live_source" label="30220" type="enum" values="Any|Akamai|Limelight" default="0" enable="eq(-5,true)" />


### PR DESCRIPTION
This should allow people without inputstream.adaptive to install and use the addon. 
If they have it and enable it they can use it.