### PR TITLE
ignore https warnings

### DIFF
--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -19,6 +19,9 @@ import xbmcplugin
 
 ADDON = xbmcaddon.Addon(id='plugin.video.iplayerwww')
 
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
 
 def GetAddonInfo():
     addon_info = {}
@@ -256,7 +259,7 @@ def CheckLogin(logged_in):
 
 def OpenURL(url):
     try:
-        r = requests.get(url, headers=headers, cookies=cookie_jar)
+        r = requests.get(url, headers=headers, cookies=cookie_jar, verify=False)
     except requests.exceptions.RequestException as e:
         dialog = xbmcgui.Dialog()
         dialog.ok(translation(30400), "%s" % e)
@@ -282,7 +285,7 @@ def OpenURLPost(url, post_data):
                    'Content-Type':'application/x-www-form-urlencoded'}
     try:
         r = requests.post(url, headers=headers_ssl, data=post_data, allow_redirects=False,
-                          cookies=cookie_jar)
+                          cookies=cookie_jar, verify=False)
     except requests.exceptions.RequestException as e:
         dialog = xbmcgui.Dialog()
         dialog.ok(translation(30400), "%s" % e)


### PR DESCRIPTION
The http only method from plugin.video.iplayerwww-2.5.13~alpha.zip won't find all the streams for some programs but this does and plays them fine on:

Kodi (16.1 Git:2016-04-24-c327c53). Platform: Android ARM 32-bit
MBX MXQ with Android 4.4.2 API level 19, kernel: Linux ARM 32-bit version 3.10.33

If you test with this you will find that the http method only finds the 2.4Mbps streams for some programs like Anthony Joshua in Most Popular.
This will find and play the 5.5Mbps streams too.

This still only works with Akamai only for me but I think that is a different problem.