### PR TITLE
stream['kind'] == 'technical-replacement'

### DIFF
--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -1555,6 +1555,7 @@ def ScrapeAvailableStreams(url):
         for stream in json_data['episode']['versions']:
             if ((stream['kind'] == 'original') or
                (stream['kind'] == 'iplayer-version') or
+               (stream['kind'] == 'technical-replacement') or
                (stream['kind'] == 'editorial')):
                 stream_id_st = stream['id']
             elif ((stream['kind'] == 'signed') and


### PR DESCRIPTION
Katy Perry fix.

It could do with some fallback fix if none of the stream types match but there is still something in the versions.

I've done it this way but I ignore everything but the main stream type.
https://github.com/primaeval/plugin.video.bbc/blob/master/main.py#L575