### PR TITLE
consume signed and ad kind streams

### DIFF
--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -1559,12 +1559,12 @@ def ScrapeAvailableStreams(url):
                (stream['kind'] == 'shortened') or
                (stream['kind'] == 'webcast')):
                 stream_id_st = stream['id']
-            elif ((stream['kind'] == 'signed') and
-                 (ADDON.getSetting('search_signed') == 'true')):
-                stream_id_sl = stream['id']
-            elif ((stream['kind'] == 'audio-described') and
-                 (ADDON.getSetting('search_ad') == 'true')):
-                stream_id_ad = stream['id']
+            elif (stream['kind'] == 'signed'):
+                if (ADDON.getSetting('search_signed') == 'true'):
+                    stream_id_sl = stream['id']
+            elif (stream['kind'] == 'audio-described'):
+                if (ADDON.getSetting('search_ad') == 'true'):
+                    stream_id_ad = stream['id']
             else:
                 print "iPlayer WWW warning: New stream kind: %s" % stream['kind']
                 stream_id_st = stream['id']


### PR DESCRIPTION
You were right. It did mess up the streams.
This should consume the ad and signed kinds if they are found when disabled.