### PR TITLE
Hide Watched fix for Live Streams

### DIFF
--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -11,6 +11,7 @@ import cookielib
 import urllib
 import HTMLParser
 import codecs
+import time
 
 import xbmc
 import xbmcaddon
@@ -324,7 +325,8 @@ def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=N
                     "&description=" + utf8_quote_plus(description) +
                     "&subtitles_url=" + utf8_quote_plus(subtitles_url) +
                     "&logged_in=" + str(logged_in))
-
+    if mode in (101,203,113,213):
+        listitem_url = listitem_url + "&time=" + str(time.time())
     if aired:
         ymd = aired.split('-')
         date_string = ymd[2] + '/' + ymd[1] + '/' + ymd[0]


### PR DESCRIPTION
This should stop the Live Streams being hidden if someone uses the Hide Watched button by adding the time variable to the url.

Please make sure the modes are right. I checked it but it could do with a double check.