### PR TITLE
highlights fallback

### DIFF
--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -803,7 +803,9 @@ def ListHighlights(highlights_url):
     """Creates a list of the programmes in the highlights section.
     """
 
-    html = OpenURL('http://www.bbc.co.uk/%s' % highlights_url)
+    found = False
+    #html = OpenURL('https://www.bbc.co.uk/%s' % highlights_url) # Krypton
+    html = OpenURL('http://www.bbc.co.uk/%s' % highlights_url) # Jarvis
 
     inner_anchors = re.findall(r'<a.*?(?!<a).*?</a>',html,flags=(re.DOTALL | re.MULTILINE))
 
@@ -875,6 +877,7 @@ def ListHighlights(highlights_url):
 
         AddMenuEntry('[B]%s: %s[/B] - %s %s' % (translation(30314), name, count, translation(30315)),
                      url, 128, '', '', '')
+        found = True
 
     # New group types for Channel Highlights.
     groups = [a for a in inner_anchors if re.match(
@@ -928,6 +931,7 @@ def ListHighlights(highlights_url):
 
             AddMenuEntry('[B]%s: %s[/B] - %s %s' % (translation(30314), name, count, translation(30315)),
                          url, 128, '', '', '')
+            found = True
 
     # Some programmes show up twice in HTML, once inside the groups, once outside.
     # We need to parse both to avoid duplicates and to make sure we get all of them.
@@ -1108,6 +1112,14 @@ def ListHighlights(highlights_url):
         if ((ADDON.getSetting('suppress_incomplete') == 'false') or (not episode[4] == '')):
             if episode[0]:
                 CheckAutoplay(episode[1], episode_url, episode[3], episode[2], episode[4])
+                found = True
+
+    if not found:
+        hrefs = re.findall(r'href="([^"]*?/episode/[^"]*?)"',html)
+        for href in hrefs:
+            title = href.split('/')[-1]
+            title = title.replace('-',' ').title()
+            CheckAutoplay(title, href, "", "", "")
 
     xbmcplugin.addSortMethod(int(sys.argv[1]), xbmcplugin.SORT_METHOD_VIDEO_TITLE)
     xbmcplugin.addSortMethod(int(sys.argv[1]), xbmcplugin.SORT_METHOD_DATE)

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -1102,9 +1102,11 @@ def ListHighlights(highlights_url):
             if object_type == "editorial-promo":
                 if episode_id:
                     AddMenuEntry('[B]%s[/B]' % (name), episode_id, 128, icon, '', '')
+                    found = True
             else:
                 if url:
                     CheckAutoplay(name, url, icon, desc, aired)
+                    found = True
 
     # Finally add all programmes which have been identified as part of a group before.
     for episode in episodelist:


### PR DESCRIPTION
I can't find a way around the https on the default highlights page and the https is broken in Jarvis. I think you'll just have to leave out the main Highlights in Jarvis. I hope they don't force https for the other pages.

If you use https for all the highlights in should work in Krypton.

The fallback code for finding episode links will be triggered if no others are found.

It works but probably needs some tweaks.
