### PR TITLE
Add proxy support

### DIFF
--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -1632,6 +1632,16 @@ def PlayStream(name, url, iconimage, description, subtitles_url):
     liz = xbmcgui.ListItem(name, iconImage='DefaultVideo.png', thumbnailImage=iconimage)
     liz.setInfo(type='Video', infoLabels={'Title': name})
     liz.setProperty("IsPlayable", "true")
+    if int(ADDON.getSetting('proxy_type')) > 0:
+        proxy_types = ["none", "http", "https", "socks5"]
+        liz.setProperty("proxy.type", proxy_types[int(ADDON.getSetting('proxy_type'))])
+        liz.setProperty("proxy.host", ADDON.getSetting('proxy_host'))
+        liz.setProperty("proxy.port", str(ADDON.getSetting('proxy_port')))
+        if ADDON.getSetting('proxy_user'):
+            liz.setProperty("proxy.user", ADDON.getSetting('proxy_user'))
+        if ADDON.getSetting('proxy_pass'):
+            liz.setProperty("proxy.password", ADDON.getSetting('proxy_pass'))
+ 
     liz.setPath(url)
     if ADDON.getSetting('stream_protocol') == '0':
         liz.setProperty('inputstreamaddon', 'inputstream.adaptive')

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -52,5 +52,11 @@
     <setting id="radio_source" label="30231" type="enum" values="Any|Akamai|Limelight" default="0" enable="eq(-8,true)" />
     <setting id="radio_location" label="30232" type="enum" values="UK|International" default="0" enable="eq(-9,true)" />
     <setting id="radio_live_bitrate" label="30233" type="enum" values="48 Kbps|96 Kbps|128 Kbps|320 Kbps" default="3" enable="eq(-10,true)" />
+    <setting label="30600" type="lsep"  />
+    <setting id="proxy_type" label="30601" type="enum" values="none|http|https|socks5" default="0" enable="true" />
+    <setting id="proxy_host" label="30602" type="text" default="localhost" enable="gt(-1, 0)" />
+    <setting id="proxy_port" label="30603" type="number" default="8081" enable="gt(-2, 0)" />
+    <setting id="proxy_user" label="30604" type="text" enable="gt(-3, 0)" />
+    <setting id="proxy_pass" label="30605" type="text" enable="gt(-4, 0)" />
 </category>
 </settings>


### PR DESCRIPTION
This patch adds proxy support to the iplayer addon.
Currenlt I am using it on Krypton, but if it is acceptable, I can make it work with leia too.