### PR TITLE
prevent duplication of final subtitle

### DIFF
--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -174,6 +174,7 @@ def download_subtitles(url):
             else:
                 entry = "%d\n%s,%s --> %s,%s\n%s\n\n" % (
                     i, prev['start'], prev['start_mil'], prev['end'], prev['end_mil'], prev['text'])
+            prev = None
 
         # get color for this line
         color = getSubColor(line, styles)


### PR DESCRIPTION
Final subtitle was being duplicated for lines containing closing tags (`</div>`, `</body>`) at end of TTML file. Final subtitle is now cleared after use to prevent this from happening