### PR TITLE
Look for alternate in-page JSON stream data

### DIFF
--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -1239,11 +1239,16 @@ def ScrapeAvailableStreams(url):
     stream_id_sl = []
     stream_id_ad = []
 
+    format = 1
     match = re.search(r'window\.mediatorDefer\=page\(document\.getElementById\(\"tviplayer\"\),(.*?)\);', html, re.DOTALL)
+    if not match:
+        format = 2
+        match = re.search(r'window.__IPLAYER_REDUX_STATE__ = (.*?);\s*</script>', html, re.DOTALL)
     if match:
         data = match.group(1)
         json_data = json.loads(data)
-        json_data = json_data['appStoreState']
+        if format == 1:
+            json_data = json_data['appStoreState']
         # print json.dumps(json_data, indent=2, sort_keys=True)
         if 'title' in json_data['episode']:
             name = json_data['episode']['title']


### PR DESCRIPTION
For TV programmes, the in-page JSON used for scraping stream data appears to be different if a user is signed in. This commit enables a fallback to check that alternate JSON if no match is made with the default pattern. The parsing switch could be based on the signed-in status of the user, but it seemed better to implement it as a fallback for a bit of future-proofing.