### PR TITLE
Fixed sign-in failing due to change in extracted URLs

### DIFF
--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -232,7 +232,7 @@ def SignInBBCiD():
         m = p.search(resp.text)
         url = m.group(1)
 
-        url = "https://account.bbc.com%s" % url
+        url = "https://account.bbc.com%s" % HTMLParser.HTMLParser().unescape(url)
         resp = s.post(url, data=post_data, headers=headers)
     
         for cookie in s.cookies:
@@ -248,7 +248,7 @@ def SignInBBCiD():
         m = p.search(resp.text)
         url = m.group(1)
 
-        url = "https://account.bbc.com%s" % url
+        url = "https://account.bbc.com%s" % HTMLParser.HTMLParser().unescape(url)
         resp = s.post(url, data=post_data, headers=headers)
     
         for cookie in s.cookies:


### PR DESCRIPTION
The URLs extracted during sign-in now appear to have multiple query
string parameters, so XML character entity (`&amp;`) must be unescaped.