### PR TITLE
Fixed sign-in failed due to changes at BBC

### DIFF
--- a/default.py
+++ b/default.py
@@ -51,7 +51,6 @@ mode = None
 iconimage = None
 description = None
 subtitles_url = None
-logged_in = False
 keyword = None
 
 
@@ -81,10 +80,6 @@ except:
     pass
 try:
     subtitles_url = Common.utf8_unquote_plus(params["subtitles_url"])
-except:
-    pass
-try:
-    logged_in = params['logged_in'] == 'True'
 except:
     pass
 try:
@@ -119,10 +114,10 @@ elif mode == 106:
     Video.ListHighlights(url)
 
 elif mode == 107:
-    Video.ListWatching(logged_in)
+    Video.ListWatching()
 
 elif mode == 108:
-    Video.ListFavourites(logged_in)
+    Video.ListFavourites()
 
 elif mode == 109:
     Video.ListChannelHighlights()
@@ -143,10 +138,10 @@ elif mode == 116:
     Radio.ListMostPopular()
 
 elif mode == 117:
-    Radio.ListListenList(logged_in)
+    Radio.ListListenList()
 
 elif mode == 199:
-    Radio.ListFollowing(logged_in)
+    Radio.ListFollowing()
 
 elif mode == 118:
     Video.RedButtonDialog()

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -284,14 +284,16 @@ def SignInBBCiD(cookies=cookie_jar):
 
 
 def SignOutBBCiD():
+    """Sign out from BBC account
+
+    Clearing the cookie jar is absolutely enough to get signed out, but
+    let's be nice and inform the Beeb as well.
+    """
     sign_out_url="https://account.bbc.com/signout"
     OpenURL(sign_out_url)
     cookie_jar.clear()
     cookie_jar.save()
-    if (StatusBBCiD()):
-        xbmcgui.Dialog().notification(translation(30326), translation(30310))
-    else:
-        xbmcgui.Dialog().notification(translation(30326), translation(30309))
+    xbmcgui.Dialog().notification(translation(30326), translation(30309))
 
 
 def StatusBBCiD(cookies=cookie_jar):

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -406,7 +406,7 @@ def utf8_unquote_plus(str):
     return urllib.parse.unquote_plus(str)
 
 
-def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=None, resolution=None, logged_in=False):
+def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=None, resolution=None):
     """Adds a new line to the Kodi list of playables.
     It is used in multiple ways in the plugin, which are distinguished by modes.
     """
@@ -417,8 +417,7 @@ def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=N
                     "&name=" + utf8_quote_plus(name) +
                     "&iconimage=" + utf8_quote_plus(iconimage) +
                     "&description=" + utf8_quote_plus(description) +
-                    "&subtitles_url=" + utf8_quote_plus(subtitles_url) +
-                    "&logged_in=" + str(logged_in))
+                    "&subtitles_url=" + utf8_quote_plus(subtitles_url))
     if mode in (101,203,113,213):
         listitem_url = listitem_url + "&time=" + str(time.time())
     if aired:

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -326,10 +326,8 @@ def StatusBBCiD(cookies=cookie_jar):
         return False
 
 
-def CheckLogin(logged_in):
-    if(logged_in == True or StatusBBCiD() == True):
-        return True
-    elif ADDON.getSetting('bbc_id_enabled') != 'true':
+def CheckLogin():
+    if ADDON.getSetting('bbc_id_enabled') != 'true':
         xbmcgui.Dialog().ok(translation(30308), translation(30311))
     else:
         if ADDON.getSetting('bbc_id_autologin') == 'true':
@@ -343,7 +341,6 @@ def CheckLogin(logged_in):
                 return True
             else:
                 xbmcgui.Dialog().notification(translation(30308), translation(30310))
-
     return False
 
 

--- a/resources/lib/ipwww_radio.py
+++ b/resources/lib/ipwww_radio.py
@@ -544,7 +544,7 @@ def ListLive():
             AddMenuEntry(name, id, 133, iconimage, '', '')
 
 
-def ListListenList(logged_in):
+def ListListenList():
     """Scrapes all episodes of the favourites page."""
     html = OpenURL('http://www.bbc.co.uk/radio/favourites')
 
@@ -611,7 +611,7 @@ def ListListenList(logged_in):
     xbmcplugin.addSortMethod(int(sys.argv[1]), xbmcplugin.SORT_METHOD_UNSORTED)
 
 
-def ListFollowing(logged_in):
+def ListFollowing():
     """Scrapes all episodes of the favourites page."""
     html = OpenURL('https://www.bbc.co.uk/radio/favourites/programmes')
 

--- a/resources/lib/ipwww_radio.py
+++ b/resources/lib/ipwww_radio.py
@@ -545,10 +545,6 @@ def ListLive():
 
 
 def ListListenList(logged_in):
-    if(CheckLogin(logged_in) == False):
-        CreateBaseDirectory('audio')
-        return
-
     """Scrapes all episodes of the favourites page."""
     html = OpenURL('http://www.bbc.co.uk/radio/favourites')
 
@@ -616,10 +612,6 @@ def ListListenList(logged_in):
 
 
 def ListFollowing(logged_in):
-    if(CheckLogin(logged_in) == False):
-        CreateBaseDirectory('audio')
-        return
-
     """Scrapes all episodes of the favourites page."""
     html = OpenURL('https://www.bbc.co.uk/radio/favourites/programmes')
 

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -945,34 +945,37 @@ def AddAvailableLiveStreamsDirectory(name, channelname, iconimage):
         AddMenuEntry(title, url, 201, iconimage, '', '')
 
 
-def ListWatching(logged_in):
-
-    if(CheckLogin(logged_in) == False):
-        CreateBaseDirectory('video')
-        return
-
-    cookie_jar = None
-    cookie_jar = GetCookieJar()
-    url = "https://www.bbc.co.uk/iplayer/watching"
+def GetJsonDataWithBBCid(url, retry=True):
     html = OpenURL(url)
     json_data = ScrapeJSON(html)
-    if json_data:
-        ParseJSON(json_data, url)
+    if not json_data:
+        xbmc.log(f"[ipwww_video] [Warning] No JSON data on page '{url}'.")
+        return
+    if json_data['id']['signedIn']:
+        return json_data
+
+    if retry:
+        if CheckLogin():
+            return GetJsonDataWithBBCid(url, retry=False)
+        else:
+            CreateBaseDirectory('video')
+    else:
+        xbmc.log('[ipwww_video] [Error] GetJsonDataWithBBCid(): still not signed in at second attempt')
+        return
+
+
+def ListWatching(logged_in):
+    url = "https://www.bbc.co.uk/iplayer/watching"
+    data = GetJsonDataWithBBCid(url)
+    if data:
+        ParseJSON(data, url)
 
 
 def ListFavourites(logged_in):
-
-    if(CheckLogin(logged_in) == False):
-        CreateBaseDirectory('video')
-        return
-
-    cookie_jar = None
-    cookie_jar = GetCookieJar()
     url = "https://www.bbc.co.uk/iplayer/added"
-    html = OpenURL(url)
-    json_data = ScrapeJSON(html)
-    if json_data:
-        ParseJSON(json_data, url)
+    data = GetJsonDataWithBBCid(url)
+    if data:
+        ParseJSON(data, url)
 
 
 def PlayStream(name, url, iconimage, description, subtitles_url):

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -964,14 +964,14 @@ def GetJsonDataWithBBCid(url, retry=True):
         return
 
 
-def ListWatching(logged_in):
+def ListWatching():
     url = "https://www.bbc.co.uk/iplayer/watching"
     data = GetJsonDataWithBBCid(url)
     if data:
         ParseJSON(data, url)
 
 
-def ListFavourites(logged_in):
+def ListFavourites():
     url = "https://www.bbc.co.uk/iplayer/added"
     data = GetJsonDataWithBBCid(url)
     if data:


### PR DESCRIPTION
Fixes failure to sign-in with BBC ID, first noticed a few day ago.
Also mentioned in [this post](https://forum.kodi.tv/showthread.php?tid=353349&pid=3170191#pid3170191) on the Kodi forum.

This implements the new method of signing in.
Log-in no longer follows all redirects, only the necessary ones.
Does authentication on domain bbc.com in the same session as bbc.co.uk, so posting username/password only needs to be done once. This altogether saves a few of requests, making signing in a bit faster. 

Authentication on bbc.com is only done because it already was before. I wonder if iplayer actually uses urls on that domain. It would save a number of requests if we could skip this.

Login was successful if SignInBBCiD() returns True. No further checking should be required.


