### PR TITLE
fix: unhandled exception when geo blocked.

### DIFF
--- a/default.py
+++ b/default.py
@@ -87,150 +87,153 @@ try:
 except:
     pass
 
-# These are the modes which tell the plugin where to go.
-if mode == 1:
-    Common.KidsMode()
+try:
+    # These are the modes which tell the plugin where to go.
+    if mode == 1:
+        Common.KidsMode()
 
-elif mode is None or url is None or len(url) < 1:
-    Common.CreateBaseDirectory(content_type)
+    elif mode is None or url is None or len(url) < 1:
+        Common.CreateBaseDirectory(content_type)
 
-# Modes 101-119 will create a main directory menu entry
-elif mode == 101:
-    Video.ListLive()
+    # Modes 101-119 will create a main directory menu entry
+    elif mode == 101:
+        Video.ListLive()
 
-elif mode == 102:
-    Video.ListAtoZ()
+    elif mode == 102:
+        Video.ListAtoZ()
 
-elif mode == 103:
-    Video.ListCategories()
+    elif mode == 103:
+        Video.ListCategories()
 
-elif mode == 104:
-    Video.Search(keyword)
+    elif mode == 104:
+        Video.Search(keyword)
 
-elif mode == 105:
-    Video.ListMostPopular()
+    elif mode == 105:
+        Video.ListMostPopular()
 
-elif mode == 106:
-    Video.ListHighlights(url)
+    elif mode == 106:
+        Video.ListHighlights(url)
 
-elif mode == 107:
-    Video.ListWatching()
+    elif mode == 107:
+        Video.ListWatching()
 
-elif mode == 108:
-    Video.ListFavourites()
+    elif mode == 108:
+        Video.ListFavourites()
 
-elif mode == 109:
-    Video.ListChannelHighlights()
+    elif mode == 109:
+        Video.ListChannelHighlights()
 
-elif mode == 112:
-    Radio.ListAtoZ()
+    elif mode == 112:
+        Radio.ListAtoZ()
 
-elif mode == 113:
-    Radio.ListLive()
+    elif mode == 113:
+        Radio.ListLive()
 
-elif mode == 114:
-    Radio.ListGenres()
+    elif mode == 114:
+        Radio.ListGenres()
 
-elif mode == 115:
-    Radio.Search(keyword)
+    elif mode == 115:
+        Radio.Search(keyword)
 
-elif mode == 116:
-    Radio.ListMostPopular()
+    elif mode == 116:
+        Radio.ListMostPopular()
 
-elif mode == 117:
-    Radio.ListListenList()
+    elif mode == 117:
+        Radio.ListListenList()
 
-elif mode == 199:
-    Radio.ListFollowing()
+    elif mode == 199:
+        Radio.ListFollowing()
 
-elif mode == 118:
-    Video.RedButtonDialog()
+    elif mode == 118:
+        Video.RedButtonDialog()
 
-elif mode == 119:
-    Common.SignOutBBCiD()
+    elif mode == 119:
+        Common.SignOutBBCiD()
 
-elif mode == 120:
-    Video.ListChannelAtoZ()
+    elif mode == 120:
+        Video.ListChannelAtoZ()
 
-    # Modes 121-199 will create a sub directory menu entry
-elif mode == 121:
-    Video.GetEpisodes(url)
+        # Modes 121-199 will create a sub directory menu entry
+    elif mode == 121:
+        Video.GetEpisodes(url)
 
-elif mode == 122:
-    Video.GetAvailableStreams(name, url, iconimage, description)
+    elif mode == 122:
+        Video.GetAvailableStreams(name, url, iconimage, description)
 
-elif mode == 123:
-    Video.AddAvailableLiveStreamsDirectory(name, url, iconimage)
+    elif mode == 123:
+        Video.AddAvailableLiveStreamsDirectory(name, url, iconimage)
 
-elif mode == 124:
-    Video.GetAtoZPage(url)
+    elif mode == 124:
+        Video.GetAtoZPage(url)
 
-elif mode == 125:
-    Video.ListCategoryFilters(url)
+    elif mode == 125:
+        Video.ListCategoryFilters(url)
 
-elif mode == 126:
-    Video.GetFilteredCategory(url)
+    elif mode == 126:
+        Video.GetFilteredCategory(url)
 
-elif mode == 127:
-    Video.GetGroup(url)
+    elif mode == 127:
+        Video.GetGroup(url)
 
-elif mode == 128:
-    Video.ScrapeEpisodes(url)
+    elif mode == 128:
+        Video.ScrapeEpisodes(url)
 
-elif mode == 129:
-    Video.AddAvailableRedButtonDirectory(name, url)
+    elif mode == 129:
+        Video.AddAvailableRedButtonDirectory(name, url)
 
-elif mode == 131:
-    Radio.GetEpisodes(url)
+    elif mode == 131:
+        Radio.GetEpisodes(url)
 
-elif mode == 132:
-    Radio.GetAvailableStreams(name, url, iconimage, description)
+    elif mode == 132:
+        Radio.GetAvailableStreams(name, url, iconimage, description)
 
-elif mode == 133:
-    Radio.AddAvailableLiveStreamsDirectory(name, url, iconimage)
+    elif mode == 133:
+        Radio.AddAvailableLiveStreamsDirectory(name, url, iconimage)
 
-elif mode == 134:
-    Video.ScrapeAtoZEpisodes(url)
+    elif mode == 134:
+        Video.ScrapeAtoZEpisodes(url)
 
-elif mode == 136:
-    Radio.GetPage(url)
+    elif mode == 136:
+        Radio.GetPage(url)
 
-elif mode == 137:
-    Radio.GetCategoryPage(url)
+    elif mode == 137:
+        Radio.GetCategoryPage(url)
 
-elif mode == 138:
-    Radio.GetAtoZPage(url)
+    elif mode == 138:
+        Radio.GetAtoZPage(url)
 
-elif mode == 139:
-    Video.ScrapeEpisodes(url)
+    elif mode == 139:
+        Video.ScrapeEpisodes(url)
 
-# Modes 201-299 will create a playable menu entry, not a directory
-elif mode == 201:
-    Video.PlayStream(name, url, iconimage, description, subtitles_url)
+    # Modes 201-299 will create a playable menu entry, not a directory
+    elif mode == 201:
+        Video.PlayStream(name, url, iconimage, description, subtitles_url)
 
-elif mode == 202:
-    Video.AddAvailableStreamItem(name, url, iconimage, description)
+    elif mode == 202:
+        Video.AddAvailableStreamItem(name, url, iconimage, description)
 
-elif mode == 203:
-    Video.AddAvailableLiveStreamItemSelector(name, url, iconimage)
+    elif mode == 203:
+        Video.AddAvailableLiveStreamItemSelector(name, url, iconimage)
 
-elif mode == 204:
-    Video.AddAvailableRedButtonItem(name, url)
+    elif mode == 204:
+        Video.AddAvailableRedButtonItem(name, url)
 
-elif mode == 205:
-    Video.AddAvailableUHDTrialItem(name, url)
+    elif mode == 205:
+        Video.AddAvailableUHDTrialItem(name, url)
 
-elif mode == 211:
-    Radio.PlayStream(name, url, iconimage, description, subtitles_url)
+    elif mode == 211:
+        Radio.PlayStream(name, url, iconimage, description, subtitles_url)
 
-elif mode == 212:
-    Radio.AddAvailableStreamItem(name, url, iconimage, description)
+    elif mode == 212:
+        Radio.AddAvailableStreamItem(name, url, iconimage, description)
 
-elif mode == 213:
-    Radio.AddAvailableLiveStreamItem(name, url, iconimage)
+    elif mode == 213:
+        Radio.AddAvailableLiveStreamItem(name, url, iconimage)
 
-elif mode == 197:
-    Video.ListUHDTrial()
-
+    elif mode == 197:
+        Video.ListUHDTrial()
+except Common.IpwwwError as err:
+    xbmcgui.Dialog().ok(Common.translation(30400), str(err))
+    sys.exit(1)
 
 xbmcplugin.endOfDirectory(int(sys.argv[1]))

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -392,6 +392,10 @@ msgctxt "#30413"
 msgid "Please check you installed this plugin correctly."
 msgstr ""
 
+msgctxt "#30414"
+msgid "This BBC Sounds programme is available to play in the UK only."
+msgstr ""
+
 msgctxt "#30500"
 msgid "Display"
 msgstr ""
@@ -475,4 +479,3 @@ msgstr ""
 msgctxt "#30529"
 msgid "iPlayer: UHD Trial Channels"
 msgstr ""
-

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -28,6 +28,14 @@ except:
 ADDON = xbmcaddon.Addon(id='plugin.video.iplayerwww')
 
 
+class IpwwwError(Exception):
+    pass
+
+
+class GeoBlockedError(IpwwwError):
+    pass
+
+
 def tp(path):
     return xbmcvfs.translatePath(path)
 

--- a/resources/lib/ipwww_radio.py
+++ b/resources/lib/ipwww_radio.py
@@ -5,7 +5,8 @@ import os
 import re
 from operator import itemgetter
 from resources.lib.ipwww_common import translation, AddMenuEntry, OpenURL, \
-                                       CheckLogin, CreateBaseDirectory, GetJWT
+                                       CheckLogin, CreateBaseDirectory, GetJWT, \
+                                       GeoBlockedError
 
 import xbmc
 import xbmcvfs
@@ -378,9 +379,7 @@ def PlayStream(name, url, iconimage, description, subtitles_url):
         '<H1>Access Denied</H1>', html)
     if check_geo or not html:
         # print "Geoblock detected, raising error message"
-        dialog = xbmcgui.Dialog()
-        dialog.ok(translation(30400), translation(30401))
-        raise
+        raise GeoBlockedError(translation(30414))
     liz = xbmcgui.ListItem(name)
     liz.setArt({'icon':'DefaultVideo.png', 'thumb':iconimage})
 
@@ -874,9 +873,7 @@ def ParseStreams(stream_id, jwt):
             elif 'result' in json_data:
                 if json_data['result'] == 'geolocation':
                     # print "Geoblock detected, raising error message"
-                    dialog = xbmcgui.Dialog()
-                    dialog.ok(translation(30400), translation(30401))
-                    raise
+                    raise GeoBlockedError(translation(30414))
     return retlist
 
 

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -11,7 +11,7 @@ import json
 from operator import itemgetter
 from resources.lib.ipwww_common import translation, AddMenuEntry, OpenURL, \
                                        CheckLogin, CreateBaseDirectory, GetCookieJar, \
-                                       ParseImageUrl, download_subtitles
+                                       ParseImageUrl, download_subtitles, GeoBlockedError
 
 import xbmc
 import xbmcvfs
@@ -986,9 +986,7 @@ def PlayStream(name, url, iconimage, description, subtitles_url):
         '<H1>Access Denied</H1>', html)
     if check_geo or not html:
         # print "Geoblock detected, raising error message"
-        dialog = xbmcgui.Dialog()
-        dialog.ok(translation(30400), translation(30401))
-        raise
+        raise GeoBlockedError(translation(30401))
     liz = xbmcgui.ListItem(name)
     liz.setArt({'icon':'DefaultVideo.png', 'thumb':iconimage})
     liz.setInfo(type='Video', infoLabels={'Title': name})
@@ -1067,9 +1065,7 @@ def ParseMediaselector(stream_id):
         elif 'result' in json_data:
             if json_data['result'] == 'geolocation':
                 # print "Geoblock detected, raising error message"
-                dialog = xbmcgui.Dialog()
-                dialog.ok(translation(30400), translation(30401))
-                raise
+                raise GeoBlockedError(translation(30401))
     # print("Found streams:")
     # print(streams)
     # print(subtitles)


### PR DESCRIPTION
When accessing geo blockked content from outside of the UK the addon threw an unhandled RunTimeError together with a message dialog.
Geo blocked radio were presented with a message mentioning 'TV progrogrammes'.

This PR handles the geo blocked message dialog in a central place and exits gracefully. And displays a suitable message on geo blocked radio programmes, e.g. Radio 5 Sport Extra