### PR TITLE
BCCiD integration part 1: continue watching

### DIFF
--- a/default.py
+++ b/default.py
@@ -237,6 +237,11 @@ try:
 
     elif mode == 197:
         Video.ListUHDTrial()
+
+    # Modes 301 - 399: Context menu handlers
+    elif mode == 301:
+        Video.RemoveWatching(episode_id)
+
 except Common.IpwwwError as err:
     xbmcgui.Dialog().ok(Common.translation(30400), str(err))
     sys.exit(1)

--- a/default.py
+++ b/default.py
@@ -87,6 +87,8 @@ try:
 except:
     pass
 
+episode_id = Common.utf8_unquote_plus(params.get('episode_id', ''))
+stream_id = Common.utf8_unquote_plus(params.get('stream_id', ''))
 resume_time = params.get('resume_time', '')
 total_time = params.get('total_time', '')
 
@@ -210,7 +212,7 @@ try:
 
     # Modes 201-299 will create a playable menu entry, not a directory
     elif mode == 201:
-        Video.PlayStream(name, url, iconimage, description, subtitles_url)
+        Video.PlayStream(name, url, iconimage, description, subtitles_url, episode_id, stream_id)
 
     elif mode == 202:
         Video.AddAvailableStreamItem(name, url, iconimage, description)

--- a/default.py
+++ b/default.py
@@ -87,6 +87,9 @@ try:
 except:
     pass
 
+resume_time = params.get('resume_time', '')
+total_time = params.get('total_time', '')
+
 try:
     # These are the modes which tell the plugin where to go.
     if mode == 1:
@@ -158,7 +161,7 @@ try:
         Video.GetEpisodes(url)
 
     elif mode == 122:
-        Video.GetAvailableStreams(name, url, iconimage, description)
+        Video.GetAvailableStreams(name, url, iconimage, description, resume_time, total_time)
 
     elif mode == 123:
         Video.AddAvailableLiveStreamsDirectory(name, url, iconimage)

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -402,6 +402,24 @@ def OpenURLPost(url, post_data):
     return r
 
 
+def PostJson(url, data):
+    with requests.Session() as session:
+        session.cookies = cookie_jar
+        session.headers = headers
+        try:
+            r = session.post(url, json=data)
+            r.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            dialog = xbmcgui.Dialog()
+            dialog.ok(translation(30400), "%s" % e)
+            sys.exit(1)
+        try:
+            if r.history:
+                cookie_jar.save(ignore_discard=True)
+        except:
+            pass
+
+
 def GetCookieJar():
     return cookie_jar
 

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -417,7 +417,7 @@ def utf8_unquote_plus(str):
 
 
 def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=None, resolution=None,
-                 resume_time="", total_time="", episode_id="", stream_id=""):
+                 resume_time="", total_time="", episode_id="", stream_id="", context_mnu=None):
     """Adds a new line to the Kodi list of playables.
     It is used in multiple ways in the plugin, which are distinguished by modes.
     """
@@ -487,6 +487,9 @@ def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=N
                 "title": name,
                 "plot": description,
                 "plotoutline": description})
+
+    if context_mnu:
+        listitem.addContextMenuItems(context_mnu)
 
     video_streaminfo = {'codec': 'h264'}
     if not isFolder:

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -416,18 +416,24 @@ def utf8_unquote_plus(str):
     return urllib.parse.unquote_plus(str)
 
 
-def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=None, resolution=None):
+def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=None, resolution=None,
+                 resume_time = None, total_time = None):
     """Adds a new line to the Kodi list of playables.
     It is used in multiple ways in the plugin, which are distinguished by modes.
     """
 
     if not iconimage:
         iconimage="DefaultFolder.png"
-    listitem_url = (sys.argv[0] + "?url=" + utf8_quote_plus(url) + "&mode=" + str(mode) +
-                    "&name=" + utf8_quote_plus(name) +
-                    "&iconimage=" + utf8_quote_plus(iconimage) +
-                    "&description=" + utf8_quote_plus(description) +
-                    "&subtitles_url=" + utf8_quote_plus(subtitles_url))
+    listitem_url = ''.join((
+        sys.argv[0],
+        "?url=", utf8_quote_plus(url),
+        "&mode=", str(mode),
+        "&name=", utf8_quote_plus(name),
+        "&iconimage=", utf8_quote_plus(iconimage),
+        "&description=", utf8_quote_plus(description),
+        "&subtitles_url=", utf8_quote_plus(subtitles_url),
+        "&resume_time=", resume_time,
+        "&total_time=", total_time))
     if mode in (101,203,113,213):
         listitem_url = listitem_url + "&time=" + str(time.time())
     if aired:
@@ -463,6 +469,9 @@ def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=N
                 "plot": description,
                 "plotoutline": description,
                 "mediatype" : "episode"})
+        if resume_time:
+            listitem.setProperty('ResumeTime', resume_time)
+            listitem.setProperty('TotalTime', total_time if total_time else '7200')
     else:
         if aired:
             listitem.setInfo("video", {

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -417,7 +417,7 @@ def utf8_unquote_plus(str):
 
 
 def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=None, resolution=None,
-                 resume_time = None, total_time = None):
+                 resume_time="", total_time="", episode_id="", stream_id=""):
     """Adds a new line to the Kodi list of playables.
     It is used in multiple ways in the plugin, which are distinguished by modes.
     """
@@ -432,6 +432,8 @@ def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=N
         "&iconimage=", utf8_quote_plus(iconimage),
         "&description=", utf8_quote_plus(description),
         "&subtitles_url=", utf8_quote_plus(subtitles_url),
+        "&episode_id=", utf8_quote_plus(episode_id),
+        "&stream_id=", utf8_quote_plus(stream_id),
         "&resume_time=", resume_time,
         "&total_time=", total_time))
     if mode in (101,203,113,213):

--- a/resources/lib/ipwww_resume.py
+++ b/resources/lib/ipwww_resume.py
@@ -1,4 +1,7 @@
 
+import time
+
+import requests
 import xbmc
 
 from resources.lib import ipwww_common
@@ -37,3 +40,165 @@ def parse_watching_item(item_data):
     image = props.get('imageTemplate', 'DefaultFolder.png').replace('{recipe}', '832x468')
     return {'name': title, 'url': url, 'iconimage': image, 'plot': info,
             'resume_time': str(resume_time), 'total_time': str(duration)}
+
+
+class PlayState:
+    UNDEFINED = 0xFF00
+    PLAYING = 0xFF01
+    PAUSED = 0xFF02
+    STOPPED = 0xFF03
+
+
+class FileProgress(xbmc.Player):
+    """Monitor the play state and progress of a single file."""
+    POLL_PERIOD = 1
+    EVT_URL = 'https://user.ibl.api.bbc.co.uk/ibl/v1/user/plays'
+
+    def __init__(self, episode_id, stream_id):
+        super(FileProgress, self).__init__()
+        self._episode_id = episode_id
+        self._stream_id = stream_id
+        self._playtime = 0
+        self.sys_monitor = xbmc.Monitor()
+        self._cur_file = None
+        self._status = PlayState.UNDEFINED
+        self._event_errors = 0
+
+    @property
+    def playtime(self):
+        """Return the last known playtime in milliseconds"""
+        return int(self._playtime * 1000)
+
+    def onPlayBackResumed(self) -> None:
+        # Can also be called when the player is just paying normally, just before switching to a new file.
+        if self._status is PlayState.PAUSED:
+            self._status = PlayState.PLAYING
+            self.post_event('started')
+
+    def onPlayBackPaused(self) -> None:
+        if self._status is PlayState.PLAYING:
+            self._status = PlayState.PAUSED
+            self.post_event('paused')
+
+    def onAVStarted(self) -> None:
+        if self._status is not PlayState.UNDEFINED:
+            return
+
+        # noinspection PyBroadException
+        try:
+            self._cur_file = self.getPlayingFile()
+            self._playtime = self.getTime()
+            self._status = PlayState.PLAYING
+            self.post_event('started')
+        except Exception as err:
+            xbmc.log("[iPlayer WWW.FileProgress] Unexpected error in onAvStarted() while monitoring {}: {!r}".format(
+                self._episode_id, err))
+            self._playtime = 0
+            self._status = PlayState.STOPPED
+            return
+
+    def onAVChange(self) -> None:
+        if self._cur_file and self._cur_file != self.getPlayingFile():
+            self.onPlayBackStopped()
+
+    def onPlayBackStopped(self) -> None:
+        cur_state = self._status
+        if cur_state is PlayState.STOPPED:
+            return
+        self._status = PlayState.STOPPED
+        if cur_state is PlayState.PLAYING:
+            # iplayer doesn't have an event type like 'stopped'
+            self.post_event('paused')
+
+    def onPlayBackEnded(self) -> None:
+        self.onPlayBackStopped()
+
+    def onPlayBackError(self) -> None:
+        self.onPlayBackStopped()
+
+    def wait_until_playing(self, timeout) -> bool:
+        """Wait and return `True` when the player has started playing.
+        Return `False` when `timeout` expires, or when play has been aborted before
+        the actual playing started.
+
+        """
+        end_t = time.monotonic() + timeout
+        while self._status is PlayState.UNDEFINED:
+            if time.monotonic() >= end_t:
+                return False
+            if self.sys_monitor.waitForAbort(0.2):
+                return False
+        return not self._status is PlayState.STOPPED
+
+    def monitor_progress(self) -> None:
+        """Post heartbeat events at regular intervals while the file is playing.
+
+        """
+        if self._status is PlayState.UNDEFINED:
+            return
+        report_period = 30
+        report_t = time.monotonic() + report_period
+        while not (self.sys_monitor.waitForAbort(self.POLL_PERIOD) or self._status is PlayState.STOPPED):
+            try:
+                self._playtime = self.getTime()
+            except RuntimeError:  # Player just stopped playing
+                self.onPlayBackStopped()
+                break
+            if time.monotonic() > report_t and self._status is PlayState.PLAYING:
+                report_t += report_period
+                self.post_event('heartbeat')
+
+    def post_event(self, action):
+        data = {
+            "action": action,
+            "id": self._episode_id,
+            "offset": int(self._playtime),
+            "version_id": self._stream_id
+        }
+        try:
+            resp = requests.post(self.EVT_URL, json=data,
+                                 headers=ipwww_common.headers,
+                                 cookies=ipwww_common.cookie_jar)
+            resp.raise_for_status()
+            self._event_errors = 0
+        except requests.exceptions.HTTPError as err:
+            self._handle_http_error(err, action)
+        except requests.exceptions.RequestException as err:
+            self._handle_event_error(err)
+
+    def _handle_event_error(self, error):
+        self._event_errors += 1
+        if self._event_errors > 3:
+            # No point in going on if events continue to have errors.
+            self._status = PlayState.STOPPED
+            xbmc.log(f"[iPlayer WWW.FileProgress] Multiple consecutive event errors - monitoring aborted. Last error: {repr(error)}.")
+            return True
+
+    def _handle_http_error(self, http_error, action):
+        if http_error.response.status_code == 401:
+            self._event_errors += 1
+            # Only try to refresh tokens once and only if the user has already signed in.
+            if self._event_errors > 1:
+                self._status = PlayState.STOPPED
+                xbmc.log("[iPlayer WWW.FileProgress] Second consecutive authentication error - monitoring aborted.")
+                return
+            # Try to refresh tokens
+            if ipwww_common.StatusBBCiD():
+                self.post_event(action)
+            else:
+                xbmc.log("[iPlayer WWW.FileProgress] Not signed in with BBCiD, monitoring aborted.")
+                self._status = PlayState.STOPPED
+        else:
+            self._handle_event_error(http_error)
+
+
+def monitor_progress(episode_id, stream_id):
+    try:
+        if episode_id and stream_id:
+            play_monitor = FileProgress(episode_id, stream_id)
+
+            if play_monitor.wait_until_playing(15) is False:
+                return
+            play_monitor.monitor_progress()
+    except Exception as e:
+        xbmc.log(f"[iPlayer WWW.monitor_progress] Play progress monitoring aborted due to unhandled exception: {repr(e)}")

--- a/resources/lib/ipwww_resume.py
+++ b/resources/lib/ipwww_resume.py
@@ -38,8 +38,14 @@ def parse_watching_item(item_data):
         resume_time = ''
     info = '\n'.join((props.get('title', ''), props.get('subtitle', ''), props.get('secondarySubLabel', '')))
     image = props.get('imageTemplate', 'DefaultFolder.png').replace('{recipe}', '832x468')
+
+    ct_menus = []
+    all_episodes_link = meta.get('secondaryHref')
+    if all_episodes_link:
+        ct_menus.append(('View all episodes',
+                         f'Container.Update(plugin://plugin.video.iplayerwww/?mode=128&url=https://www.bbc.co.uk{all_episodes_link})'))
     return {'name': title, 'url': url, 'iconimage': image, 'plot': info,
-            'resume_time': str(resume_time), 'total_time': str(duration)}
+            'resume_time': str(resume_time), 'total_time': str(duration), 'context_mnu': ct_menus}
 
 
 class PlayState:

--- a/resources/lib/ipwww_resume.py
+++ b/resources/lib/ipwww_resume.py
@@ -1,0 +1,39 @@
+
+import xbmc
+
+from resources.lib import ipwww_common
+from resources.lib import ipwww_video
+
+
+def parse_watching(json_data):
+    config = json_data.get('config')
+    if not config:
+        return
+    programme_list = json_data.get('items', [])
+    for item in programme_list:
+        yield parse_watching_item(item)
+
+
+def parse_watching_item(item_data):
+    props = item_data.get('props')
+    meta = item_data.get('meta')
+    if not (props and meta and 'href' in props):
+        xbmc.log("[iPLayer WWW.parse_watching_item] Unparsable item: {}".format(item_data))
+        return
+
+    url = 'https://www.bbc.co.uk' + props['href']
+    remaining_seconds = meta.get('remaining')
+    if remaining_seconds:
+        title = '{} - [I]{} min left[/I]'.format(props.get('title', ''), int(remaining_seconds / 60))
+        duration_str = props.get('durationSubLabel', '0').split()[0]
+        duration = int(duration_str) * 60
+        # Resume a little bit earlier, so you can easily recognise where you've left off.
+        resume_time = max(int(duration - meta.get('remaining', duration)) - 10, 0)
+    else:
+        title = '{} - [I]next episode[/I]'.format(props.get('title', ''))
+        duration = ''
+        resume_time = ''
+    info = '\n'.join((props.get('title', ''), props.get('subtitle', ''), props.get('secondarySubLabel', '')))
+    image = props.get('imageTemplate', 'DefaultFolder.png').replace('{recipe}', '832x468')
+    return {'name': title, 'url': url, 'iconimage': image, 'plot': info,
+            'resume_time': str(resume_time), 'total_time': str(duration)}

--- a/resources/lib/ipwww_resume.py
+++ b/resources/lib/ipwww_resume.py
@@ -44,6 +44,11 @@ def parse_watching_item(item_data):
     if all_episodes_link:
         ct_menus.append(('View all episodes',
                          f'Container.Update(plugin://plugin.video.iplayerwww/?mode=128&url=https://www.bbc.co.uk{all_episodes_link})'))
+    programme_id = meta.get('programmeId')
+    if programme_id:
+        ct_menus.append(('Remove',
+                         f'RunPlugin(plugin://plugin.video.iplayerwww?mode=301&episode_id={programme_id}&url=url)'))
+
     return {'name': title, 'url': url, 'iconimage': image, 'plot': info,
             'resume_time': str(resume_time), 'total_time': str(duration), 'context_mnu': ct_menus}
 

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -11,7 +11,8 @@ import json
 from operator import itemgetter
 from resources.lib.ipwww_common import translation, AddMenuEntry, OpenURL, \
                                        CheckLogin, CreateBaseDirectory, GetCookieJar, \
-                                       ParseImageUrl, download_subtitles, GeoBlockedError
+                                       ParseImageUrl, download_subtitles, GeoBlockedError, \
+                                       PostJson
 from resources.lib import ipwww_resume
 
 import xbmc
@@ -978,6 +979,15 @@ def ListWatching():
     if data:
         for item_data in ipwww_resume.parse_watching(data):
             CheckAutoplay(**item_data)
+
+
+def RemoveWatching(episode_id):
+    """Remove an item from the 'continue watching' list.
+    Handler for the context menu option 'Remove' on list items in 'Continue watching'.
+    """
+    PostJson('https://user.ibl.api.bbc.co.uk/ibl/v1/user/hides',
+             {'id': episode_id})
+    xbmc.executebuiltin('Container.Refresh')
 
 
 def ListFavourites():

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -1215,10 +1215,10 @@ def ScrapeJSON(html):
     return json_data
 
 
-def CheckAutoplay(name, url, iconimage, plot, aired=None, resume_time="", total_time=""):
+def CheckAutoplay(name, url, iconimage, plot, aired=None, resume_time="", total_time="", context_mnu=None):
     if ADDON.getSetting('streams_autoplay') == 'true':
         mode = 202
     else:
         mode = 122
     AddMenuEntry(name, url, mode, iconimage, plot, '', aired=aired,
-                 resume_time=resume_time, total_time=total_time)
+                 resume_time=resume_time, total_time=total_time, context_mnu=context_mnu)

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -856,10 +856,13 @@ def AddAvailableStreamItem(name, url, iconimage, description):
         description = stream_ids['description']
     if ((not stream_ids['stream_id_st']) or (ADDON.getSetting('search_ad') == 'true')) and stream_ids['stream_id_ad']:
         streams_all = ParseStreamsHLSDASH(stream_ids['stream_id_ad'])
+        strm_id = stream_ids['stream_id_ad']
     elif ((not stream_ids['stream_id_st']) or (ADDON.getSetting('search_signed') == 'true')) and stream_ids['stream_id_sl']:
         streams_all = ParseStreamsHLSDASH(stream_ids['stream_id_sl'])
+        strm_id = stream_ids['stream_id_sl']
     else:
         streams_all = ParseStreamsHLSDASH(stream_ids['stream_id_st'])
+        strm_id = stream_ids['stream_id_st']
     if streams_all[1]:
         # print "Setting subtitles URL"
         subtitles_url = streams_all[1][0][1]
@@ -874,7 +877,8 @@ def AddAvailableStreamItem(name, url, iconimage, description):
         match = [x for x in streams if (x[0] == source)]
     else:
         match = streams
-    PlayStream(name, match[0][2], iconimage, description, subtitles_url)
+    PlayStream(name, match[0][2], iconimage, description, subtitles_url,
+               episode_id=stream_ids['episode_id'], stream_id=strm_id)
 
 
 def GetAvailableStreams(name, url, iconimage, description, resume_time='', total_time=''):
@@ -890,15 +894,15 @@ def GetAvailableStreams(name, url, iconimage, description, resume_time='', total
     # If we found standard streams, append them to the list.
     if stream_ids['stream_id_st']:
         AddAvailableStreamsDirectory(name, stream_ids['stream_id_st'], iconimage, description,
-                                     resume_time, total_time)
+                                     stream_ids['episode_id'], resume_time, total_time)
     # If we searched for Audio Described programmes and they have been found, append them to the list.
     if stream_ids['stream_id_ad'] or not stream_ids['stream_id_st']:
         AddAvailableStreamsDirectory(name + ' - (Audio Described)', stream_ids['stream_id_ad'], iconimage,
-                                     description, resume_time, total_time)
+                                     description, stream_ids['episode_id'], resume_time, total_time)
     # If we search for Signed programmes and they have been found, append them to the list.
     if stream_ids['stream_id_sl'] or not stream_ids['stream_id_st']:
         AddAvailableStreamsDirectory(name + ' - (Signed)', stream_ids['stream_id_sl'], iconimage,
-                                     description, resume_time, total_time)
+                                     description, stream_ids['episode_id'], resume_time, total_time)
 
 
 def Search(search_entered):
@@ -983,7 +987,7 @@ def ListFavourites():
         ParseJSON(data, url)
 
 
-def PlayStream(name, url, iconimage, description, subtitles_url):
+def PlayStream(name, url, iconimage, description, subtitles_url, episode_id=None, stream_id=None):
     if iconimage == '':
         iconimage = 'DefaultVideo.png'
     html = OpenURL(url)
@@ -1004,9 +1008,10 @@ def PlayStream(name, url, iconimage, description, subtitles_url):
         subtitles_file = download_subtitles(subtitles_url)
         liz.setSubtitles([subtitles_file])
     xbmcplugin.setResolvedUrl(int(sys.argv[1]), True, liz)
+    ipwww_resume.monitor_progress(episode_id, stream_id)
 
 
-def AddAvailableStreamsDirectory(name, stream_id, iconimage, description, resume_time="", total_time=""):
+def AddAvailableStreamsDirectory(name, stream_id, iconimage, description, episode_id, resume_time="", total_time=""):
     """Will create one menu entry for each available stream of a particular stream_id"""
     # print("Stream ID: %s"%stream_id)
     streams = ParseStreamsHLSDASH(stream_id)
@@ -1021,7 +1026,7 @@ def AddAvailableStreamsDirectory(name, stream_id, iconimage, description, resume
     for supplier, bitrate, url, resolution, protocol in streams[0]:
         title = name + ' - [I][COLOR ffd3d3d3]%s[/COLOR][/I]' % (suppliers[supplier])
         AddMenuEntry(title, url, 201, iconimage, description, subtitles_url, resolution=resolution,
-                     resume_time=resume_time, total_time=total_time)
+                     episode_id=episode_id, stream_id=stream_id, resume_time=resume_time, total_time=total_time)
 
 
 def ParseMediaselector(stream_id):
@@ -1187,7 +1192,8 @@ def ScrapeAvailableStreams(url):
                 xbmc.log("iPlayer WWW warning: New stream kind: %s" % stream['kind'])
                 stream_id_st = stream['id']
 
-    return {'stream_id_st': stream_id_st, 'stream_id_sl': stream_id_sl, 'stream_id_ad': stream_id_ad, 'name': name, 'image':image, 'description': description}
+    return {'stream_id_st': stream_id_st, 'stream_id_sl': stream_id_sl, 'stream_id_ad': stream_id_ad,
+            'name': name, 'image':image, 'description': description, 'episode_id': json_data['episode'].get('id', '')}
 
 
 def ScrapeJSON(html):
@@ -1209,9 +1215,10 @@ def ScrapeJSON(html):
     return json_data
 
 
-def CheckAutoplay(name, url, iconimage, plot, aired=None):
+def CheckAutoplay(name, url, iconimage, plot, aired=None, resume_time="", total_time=""):
     if ADDON.getSetting('streams_autoplay') == 'true':
-        AddMenuEntry(name, url, 202, iconimage, plot, '', aired=aired)
+        mode = 202
     else:
-        AddMenuEntry(name, url, 122, iconimage, plot, '', aired=aired)
-
+        mode = 122
+    AddMenuEntry(name, url, mode, iconimage, plot, '', aired=aired,
+                 resume_time=resume_time, total_time=total_time)


### PR DESCRIPTION
Full 2-way sync of watching status and functionality aligned with the iplayer website.
- Watching now displays a list of episodes, rather than series.
- Context menu option to view all episodes.
- Context menu option to remove an item from 'watching'.
- Playing a video from watching now plays from the resume point obtained from the BBC.
- While playing any video it's play state is send to the BBC, enabling to continue watching on another device. It fails silently and stops when a user is not signed in.

fixes #349 