### PR TITLE
BBCiD integration continue watching

### DIFF
--- a/default.py
+++ b/default.py
@@ -237,6 +237,11 @@ try:
 
     elif mode == 197:
         Video.ListUHDTrial()
+
+    # Modes 301 - 399: Context menu handlers
+    elif mode == 301:
+        Video.RemoveWatching(episode_id)
+
 except Common.IpwwwError as err:
     xbmcgui.Dialog().ok(Common.translation(30400), str(err))
     sys.exit(1)

--- a/default.py
+++ b/default.py
@@ -87,6 +87,8 @@ try:
 except:
     pass
 
+episode_id = Common.utf8_unquote_plus(params.get('episode_id', ''))
+stream_id = Common.utf8_unquote_plus(params.get('stream_id', ''))
 resume_time = params.get('resume_time', '')
 total_time = params.get('total_time', '')
 
@@ -210,7 +212,7 @@ try:
 
     # Modes 201-299 will create a playable menu entry, not a directory
     elif mode == 201:
-        Video.PlayStream(name, url, iconimage, description, subtitles_url)
+        Video.PlayStream(name, url, iconimage, description, subtitles_url, episode_id, stream_id)
 
     elif mode == 202:
         Video.AddAvailableStreamItem(name, url, iconimage, description)

--- a/default.py
+++ b/default.py
@@ -87,6 +87,9 @@ try:
 except:
     pass
 
+resume_time = params.get('resume_time', '')
+total_time = params.get('total_time', '')
+
 try:
     # These are the modes which tell the plugin where to go.
     if mode == 1:
@@ -158,7 +161,7 @@ try:
         Video.GetEpisodes(url)
 
     elif mode == 122:
-        Video.GetAvailableStreams(name, url, iconimage, description)
+        Video.GetAvailableStreams(name, url, iconimage, description, resume_time, total_time)
 
     elif mode == 123:
         Video.AddAvailableLiveStreamsDirectory(name, url, iconimage)

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -402,6 +402,24 @@ def OpenURLPost(url, post_data):
     return r
 
 
+def PostJson(url, data):
+    with requests.Session() as session:
+        session.cookies = cookie_jar
+        session.headers = headers
+        try:
+            r = session.post(url, json=data)
+            r.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            dialog = xbmcgui.Dialog()
+            dialog.ok(translation(30400), "%s" % e)
+            sys.exit(1)
+        try:
+            if r.history:
+                cookie_jar.save(ignore_discard=True)
+        except:
+            pass
+
+
 def GetCookieJar():
     return cookie_jar
 

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -436,7 +436,7 @@ def iso_duration_2_seconds(iso_str: str) -> int:
 
 
 def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=None, resolution=None,
-                 resume_time='', total_time='', episode_id='', stream_id=''):
+                 resume_time='', total_time='', episode_id='', stream_id='', context_mnu=None):
     """Adds a new line to the Kodi list of playables.
     It is used in multiple ways in the plugin, which are distinguished by modes.
     """
@@ -506,6 +506,9 @@ def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=N
                 "title": name,
                 "plot": description,
                 "plotoutline": description})
+
+    if context_mnu:
+        listitem.addContextMenuItems(context_mnu)
 
     video_streaminfo = {'codec': 'h264'}
     if not isFolder:

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -436,7 +436,7 @@ def iso_duration_2_seconds(iso_str: str) -> int:
 
 
 def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=None, resolution=None,
-                 resume_time = '', total_time = ''):
+                 resume_time='', total_time='', episode_id='', stream_id=''):
     """Adds a new line to the Kodi list of playables.
     It is used in multiple ways in the plugin, which are distinguished by modes.
     """
@@ -451,6 +451,8 @@ def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=N
         "&iconimage=", utf8_quote_plus(iconimage),
         "&description=", utf8_quote_plus(description),
         "&subtitles_url=", utf8_quote_plus(subtitles_url),
+        "&episode_id=", utf8_quote_plus(episode_id),
+        "&stream_id=", utf8_quote_plus(stream_id),
         "&resume_time=", resume_time,
         "&total_time=", total_time))
     if mode in (101,203,113,213):

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -416,6 +416,25 @@ def utf8_unquote_plus(str):
     return urllib.parse.unquote_plus(str)
 
 
+def iso_duration_2_seconds(iso_str: str) -> int:
+    """Convert an ISO 8601 duration string into seconds.
+
+    Simple parser to match durations found in films and tv episodes.
+    Handles only hours, minutes and seconds.
+
+    """
+    try:
+        if len(iso_str) > 3:
+            import re
+            match = re.match(r'^PT(?:([\d.]+)H)?(?:([\d.]+)M)?(?:([\d.]+)S)?$', iso_str)
+            if match:
+                hours, minutes, seconds = match.groups(default=0)
+                return int(float(hours) * 3600 + float(minutes) * 60 + float(seconds))
+    except (ValueError, AttributeError, TypeError):
+        pass
+    return None
+
+
 def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=None, resolution=None):
     """Adds a new line to the Kodi list of playables.
     It is used in multiple ways in the plugin, which are distinguished by modes.

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -435,18 +435,24 @@ def iso_duration_2_seconds(iso_str: str) -> int:
     return None
 
 
-def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=None, resolution=None):
+def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=None, resolution=None,
+                 resume_time = '', total_time = ''):
     """Adds a new line to the Kodi list of playables.
     It is used in multiple ways in the plugin, which are distinguished by modes.
     """
 
     if not iconimage:
         iconimage="DefaultFolder.png"
-    listitem_url = (sys.argv[0] + "?url=" + utf8_quote_plus(url) + "&mode=" + str(mode) +
-                    "&name=" + utf8_quote_plus(name) +
-                    "&iconimage=" + utf8_quote_plus(iconimage) +
-                    "&description=" + utf8_quote_plus(description) +
-                    "&subtitles_url=" + utf8_quote_plus(subtitles_url))
+    listitem_url = ''.join((
+        sys.argv[0],
+        "?url=", utf8_quote_plus(url),
+        "&mode=", str(mode),
+        "&name=", utf8_quote_plus(name),
+        "&iconimage=", utf8_quote_plus(iconimage),
+        "&description=", utf8_quote_plus(description),
+        "&subtitles_url=", utf8_quote_plus(subtitles_url),
+        "&resume_time=", resume_time,
+        "&total_time=", total_time))
     if mode in (101,203,113,213):
         listitem_url = listitem_url + "&time=" + str(time.time())
     if aired:
@@ -482,6 +488,9 @@ def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=N
                 "plot": description,
                 "plotoutline": description,
                 "mediatype" : "episode"})
+        if resume_time:
+            listitem.setProperty('ResumeTime', resume_time)
+            listitem.setProperty('TotalTime', total_time if total_time else '7200')
     else:
         if aired:
             listitem.setInfo("video", {

--- a/resources/lib/ipwww_progress.py
+++ b/resources/lib/ipwww_progress.py
@@ -1,0 +1,168 @@
+
+import time
+import requests
+import xbmc
+
+from resources.lib import ipwww_common
+
+
+class PlayState:
+    UNDEFINED = 0xFF00
+    PLAYING = 0xFF01
+    PAUSED = 0xFF02
+    STOPPED = 0xFF03
+
+
+class FileProgress(xbmc.Player):
+    """Monitor the play state and progress of a single file."""
+    POLL_PERIOD = 1
+    EVT_URL = 'https://user.ibl.api.bbc.co.uk/ibl/v1/user/plays'
+
+    def __init__(self, episode_id, stream_id):
+        super(FileProgress, self).__init__()
+        self._episode_id = episode_id
+        self._stream_id = stream_id
+        self._playtime = 0
+        self.sys_monitor = xbmc.Monitor()
+        self._cur_file = None
+        self._status = PlayState.UNDEFINED
+        self._event_errors = 0
+
+    @property
+    def playtime(self):
+        """Return the last known playtime in milliseconds"""
+        return int(self._playtime * 1000)
+
+    def onPlayBackResumed(self) -> None:
+        # Can also be called when the player is just paying normally, just before switching to a new file.
+        if self._status is PlayState.PAUSED:
+            self._status = PlayState.PLAYING
+            self.post_event('started')
+
+    def onPlayBackPaused(self) -> None:
+        if self._status is PlayState.PLAYING:
+            self._status = PlayState.PAUSED
+            self.post_event('paused')
+
+    def onAVStarted(self) -> None:
+        if self._status is not PlayState.UNDEFINED:
+            return
+
+        # noinspection PyBroadException
+        try:
+            self._cur_file = self.getPlayingFile()
+            self._playtime = self.getTime()
+            self._status = PlayState.PLAYING
+            self.post_event('started')
+        except Exception as err:
+            xbmc.log("[iPlayer WWW.FileProgress] Unexpected error in onAvStarted() while monitoring {}: {!r}".format(
+                self._episode_id, err))
+            self._playtime = 0
+            self._status = PlayState.STOPPED
+            return
+
+    def onAVChange(self) -> None:
+        if self._cur_file and self._cur_file != self.getPlayingFile():
+            self.onPlayBackStopped()
+
+    def onPlayBackStopped(self) -> None:
+        cur_state = self._status
+        if cur_state is PlayState.STOPPED:
+            return
+        self._status = PlayState.STOPPED
+        if cur_state is PlayState.PLAYING:
+            # iplayer doesn't have an event type like 'stopped'
+            self.post_event('paused')
+
+    def onPlayBackEnded(self) -> None:
+        self.onPlayBackStopped()
+
+    def onPlayBackError(self) -> None:
+        self.onPlayBackStopped()
+
+    def wait_until_playing(self, timeout) -> bool:
+        """Wait and return `True` when the player has started playing.
+        Return `False` when `timeout` expires, or when play has been aborted before
+        the actual playing started.
+
+        """
+        end_t = time.monotonic() + timeout
+        while self._status is PlayState.UNDEFINED:
+            if time.monotonic() >= end_t:
+                return False
+            if self.sys_monitor.waitForAbort(0.2):
+                return False
+        return not self._status is PlayState.STOPPED
+
+    def monitor_progress(self) -> None:
+        """Post heartbeat events at regular intervals while the file is playing.
+
+        """
+        if self._status is PlayState.UNDEFINED:
+            return
+        report_period = 30
+        report_t = time.monotonic() + report_period
+        while not (self.sys_monitor.waitForAbort(self.POLL_PERIOD) or self._status is PlayState.STOPPED):
+            try:
+                self._playtime = self.getTime()
+            except RuntimeError:  # Player just stopped playing
+                self.onPlayBackStopped()
+                break
+            if time.monotonic() > report_t and self._status is PlayState.PLAYING:
+                report_t += report_period
+                self.post_event('heartbeat')
+
+    def post_event(self, action):
+        data = {
+            "action": action,
+            "id": self._episode_id,
+            "offset": int(self._playtime),
+            "version_id": self._stream_id
+        }
+        try:
+            resp = requests.post(self.EVT_URL, json=data,
+                                 headers=ipwww_common.headers,
+                                 cookies=ipwww_common.cookie_jar)
+            resp.raise_for_status()
+            self._event_errors = 0
+        except requests.exceptions.HTTPError as err:
+            self._handle_http_error(err, action)
+        except requests.exceptions.RequestException as err:
+            self._handle_event_error(err)
+
+    def _handle_event_error(self, error):
+        self._event_errors += 1
+        if self._event_errors > 3:
+            # No point in going on if events continue to have errors.
+            self._status = PlayState.STOPPED
+            xbmc.log(f"[iPlayer WWW.FileProgress] Multiple consecutive event errors - monitoring aborted. Last error: {repr(error)}.")
+            return True
+
+    def _handle_http_error(self, http_error, action):
+        if http_error.response.status_code == 401:
+            self._event_errors += 1
+            # Only try to refresh tokens once and only if the user has already signed in.
+            if self._event_errors > 1:
+                self._status = PlayState.STOPPED
+                xbmc.log("[iPlayer WWW.FileProgress] Second consecutive authentication error - monitoring aborted.")
+                return
+            # Try to refresh tokens
+            if ipwww_common.StatusBBCiD():
+                self.post_event(action)
+            else:
+                xbmc.log("[iPlayer WWW.FileProgress] Not signed in with BBCiD, monitoring aborted.")
+                self._status = PlayState.STOPPED
+        else:
+            self._handle_event_error(http_error)
+
+
+def monitor_progress(episode_id, stream_id):
+    try:
+        if episode_id and stream_id:
+            play_monitor = FileProgress(episode_id, stream_id)
+
+            if play_monitor.wait_until_playing(15) is False:
+                return
+            play_monitor.monitor_progress()
+    except Exception as e:
+        xbmc.log(f"[iPlayer WWW.monitor_progress] Play progress monitoring aborted due to unhandled exception: {repr(e)}")

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -12,7 +12,7 @@ from operator import itemgetter
 from resources.lib.ipwww_common import translation, AddMenuEntry, OpenURL, \
                                        CheckLogin, CreateBaseDirectory, GetCookieJar, \
                                        ParseImageUrl, download_subtitles, GeoBlockedError, \
-                                       iso_duration_2_seconds
+                                       iso_duration_2_seconds, PostJson
 from resources.lib import ipwww_progress
 
 import xbmc
@@ -1030,7 +1030,22 @@ def ListWatching():
             ct_menus.append(('View all episodes',
                              f'Container.Update(plugin://plugin.video.iplayerwww/?mode=128&url={all_episodes_link})'))
 
+        programme_id = episode.get('tleo_id')
+        if programme_id:
+            ct_menus.append(('Remove',
+                             f'RunPlugin(plugin://plugin.video.iplayerwww?mode=301&episode_id={programme_id}&url=url)'))
+
         CheckAutoplay(**item_data)
+
+
+def RemoveWatching(episode_id):
+    """Remove an item from the 'Continue Watching' list.
+    Handler for the context menu option 'Remove' on list items in 'Continue watching'.
+
+    """
+    PostJson('https://user.ibl.api.bbc.co.uk/ibl/v1/user/hides',
+             {'id': episode_id})
+    xbmc.executebuiltin('Container.Refresh')
 
 
 def ListFavourites():

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -1011,6 +1011,7 @@ def ListWatching():
 
     for watching_item in data['items']['elements']:
         episode = watching_item['episode']
+        programme = watching_item['programme']
         item_data = ParseEpisode(episode)
 
         full_title =  item_data['name']
@@ -1022,6 +1023,12 @@ def ListWatching():
             item_data['resume_time'] = str(max(watching_item['offset'] - 10, 0))
         else:
             item_data['name'] = '{} - [I]next episode[/I]'.format(episode.get('title', ''))
+
+        item_data['context_mnu'] = ct_menus = []
+        if programme.get('count', 0) > 1:
+            all_episodes_link = 'https://www.bbc.co.uk/iplayer/episodes/' + programme['id']
+            ct_menus.append(('View all episodes',
+                             f'Container.Update(plugin://plugin.video.iplayerwww/?mode=128&url={all_episodes_link})'))
 
         CheckAutoplay(**item_data)
 
@@ -1261,10 +1268,10 @@ def ScrapeJSON(html):
     return json_data
 
 
-def CheckAutoplay(name, url, iconimage, description, aired=None, resume_time="", total_time=""):
+def CheckAutoplay(name, url, iconimage, description, aired=None, resume_time="", total_time="", context_mnu=None):
     if ADDON.getSetting('streams_autoplay') == 'true':
         mode = 202
     else:
         mode = 122
     AddMenuEntry(name, url, mode, iconimage, description, '', aired=aired,
-                 resume_time=resume_time, total_time=total_time)
+                 resume_time=resume_time, total_time=total_time, context_mnu=context_mnu)


### PR DESCRIPTION
Full 2-way sync of watching status and functionality aligned with the iplayer website.

Watching now displays a list of episodes, rather than series.
Context menu option to view all episodes.
Context menu option to remove an item from 'watching'.
Playing a video from watching now plays from the resume point obtained from the BBC.
While playing any video it's play state is send to the BBC, enabling to continue watching on another device. It fails silently and stops when a user is not signed in.

fixes #349

This PR implements the recently changed data returned by iplayer, is a bit re-structured, but is functional the same as the previous PR. 
Because the new data structure is also used in other listings, like Added and Recommended, there is now a parser function ParseEpisode() in ipww_video to handle this data. (At the moment Added is broken and this function could be used in a fix.)
All parsing specific to Continue Watching is now done in it's own function. 

The general idea is still the same:

**watching list**
ListWatching has it's own parser. To be honest, just because the general ParseJson() is too complex for me to comprehend and I had no idea where to fit in the new code.
The parser obtains the resume point and total playing time of the programme. Parameters and a callback argument are added, just to drag these through all functions and callbacks, supporting both manual and automatic stream selection. AddMenuEntry() will eventually set the resume point and total time as ListItem properties when it is called to add a playable.

**Play progress reports**
Progress reports send to the BCC require both programmeId and streamId. These are obtained in various parsers, and by the aid of new function and callback arguments eventually reach PlayStream(). After PlayStream() has passed the resolved url to Kodi it now keeps the addon running and starts to monitor play progress until the stream stops.

**FileProgress**
A attempt to monitor the state of a single stream and post status events to BBC just like a regular web browser. Special care is taken to handle the situation where a user starts another stream without stopping the previous one. (Kodi calls Resume() while the payer is playing and does not call Stop() at all)

