### PR TITLE
BDCiD - Added

### DIFF
--- a/default.py
+++ b/default.py
@@ -248,6 +248,9 @@ try:
     elif mode == 301:
         Video.RemoveWatching(episode_id)
 
+    elif mode == 302:
+        Video.RemoveFavourite(episode_id)
+
 except Common.IpwwwError as err:
     xbmcgui.Dialog().ok(Common.translation(30400), str(err))
     sys.exit(1)

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -221,7 +221,7 @@ msgid "Watching"
 msgstr ""
 
 msgctxt "#30307"
-msgid "Added"
+msgid "Watchlist"
 msgstr ""
 
 msgctxt "#30308"
@@ -465,7 +465,7 @@ msgid "iPlayer: Watching"
 msgstr ""
 
 msgctxt "#30521"
-msgid "iPlayer: Added"
+msgid "iPlayer: Watchlist"
 msgstr ""
 
 msgctxt "#30522"

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -420,6 +420,24 @@ def OpenURLPost(url, post_data):
     return r
 
 
+def DeleteUrl(url, **kwargs):
+    with requests.Session() as session:
+        session.cookies = cookie_jar
+        session.headers = headers
+        try:
+            r = session.delete(url, **kwargs)
+            r.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            dialog = xbmcgui.Dialog()
+            dialog.ok(translation(30400), "%s" % e)
+            sys.exit(1)
+        try:
+            if r.history:
+                cookie_jar.save(ignore_discard=True)
+        except:
+            pass
+
+
 def PostJson(url, data):
     return OpenRequest('post', url, json=data, exit_on_error=True)
 

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -8,14 +8,14 @@ import re
 import datetime
 import time
 import json
-import requests
+
 from datetime import timedelta
 from operator import itemgetter
 
 from resources.lib.ipwww_common import translation, AddMenuEntry, OpenURL, OpenRequest, \
                                        CheckLogin, CreateBaseDirectory, GetCookieJar, \
                                        ParseImageUrl, download_subtitles, GeoBlockedError, \
-                                       iso_duration_2_seconds, PostJson, strptime, addonid
+                                       iso_duration_2_seconds, PostJson, strptime, addonid, DeleteUrl
 from resources.lib import ipwww_progress
 
 import xbmc
@@ -1135,11 +1135,9 @@ def RemoveFavourite(programme_id):
     """Remove an item from the 'Added' list.
     Handler for the context menu option 'Remove' on list items in 'Added'.
 
+    Delete will never fail, even if programme_id is not on the list, or does not exist at all.
     """
-    from resources.lib.ipwww_common import headers as common_headers
-    requests.delete('https://user.ibl.api.bbc.co.uk/ibl/v1/user/adds/' + programme_id,
-                    headers=common_headers,
-                    cookies=GetCookieJar())
+    DeleteUrl('https://user.ibl.api.bbc.co.uk/ibl/v1/user/adds/' + programme_id)
     xbmc.executebuiltin('Container.Refresh')
 
 

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -763,7 +763,7 @@ def ParseJSON(programme_data, current_url):
                         AddMenuEntry('[B]%s: %s[/B]' % (name, series['title']['default']),
                                      series_url, 128, '', '', '')
         elif 'items' in programme_data:
-            # This must be Added or Watching.
+            # This must be Watchlist or Continue Watching.
             programmes = programme_data['items']
 
         if programmes:
@@ -1111,7 +1111,7 @@ def RemoveWatching(episode_id):
 
 
 def ListFavourites():
-    """AKA 'Watch List', FKA 'Added'."""
+    """AKA 'Watchlist', FKA 'Added'."""
     data = GetJsonDataWithBBCid("https://www.bbc.co.uk/iplayer/added")
     if not data:
         return
@@ -1132,8 +1132,8 @@ def ListFavourites():
 
 
 def RemoveFavourite(programme_id):
-    """Remove an item from the 'Added' list.
-    Handler for the context menu option 'Remove' on list items in 'Added'.
+    """Remove an item from the Watchlist.
+    Handler for the context menu option 'Remove' on list items in 'Watchlist'.
 
     Delete will never fail, even if programme_id is not on the list, or does not exist at all.
     """

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -8,7 +8,7 @@ import re
 import datetime
 import time
 import json
-
+import requests
 from datetime import timedelta
 from operator import itemgetter
 
@@ -876,6 +876,15 @@ def SelectImage(images):
            or images.get('portrait', 'DefaultFolder.png')).replace('{recipe}', '832x468')
 
 
+def ParseProgramme(progr_data):
+    return {
+        'url': 'https://www.bbc.co.uk/iplayer/episodes/' + progr_data['id'],
+        'name': '[B]{}[/B] - {} episodes available'.format(progr_data['title'], progr_data['count']),
+        'iconimage': progr_data.get('images', {}).get('standard', 'DefaultFolder.png').replace('{recipe}', '832x468'),
+        'description': SelectSynopsis(progr_data['synopses'])
+    }
+
+
 def ParseEpisode(episode_data):
     title = episode_data.get('title', '')
     subtitle = episode_data.get('subtitle')
@@ -1102,10 +1111,36 @@ def RemoveWatching(episode_id):
 
 
 def ListFavourites():
-    url = "https://www.bbc.co.uk/iplayer/added"
-    data = GetJsonDataWithBBCid(url)
-    if data:
-        ParseJSON(data, url)
+    """AKA 'Watch List', FKA 'Added'."""
+    data = GetJsonDataWithBBCid("https://www.bbc.co.uk/iplayer/added")
+    if not data:
+        return
+    has_episodes = False
+    for added_item in data['items']['elements']:
+        programme = added_item['programme']
+        ct_mnu = [('Remove',
+                   f'RunPlugin(plugin://plugin.video.iplayerwww?mode=302&episode_id={programme["id"]}&url=url)')]
+        if programme['count'] == 1:
+            CheckAutoplay(context_mnu=ct_mnu, **ParseEpisode(programme['initial_children'][0]))
+            has_episodes = True
+        else:
+            AddMenuEntry(mode=128, subtitles_url='', context_mnu=ct_mnu, **ParseProgramme(programme))
+    if has_episodes:
+        SetSortMethods(xbmcplugin.SORT_METHOD_DATE)
+    else:
+        SetSortMethods()
+
+
+def RemoveFavourite(programme_id):
+    """Remove an item from the 'Added' list.
+    Handler for the context menu option 'Remove' on list items in 'Added'.
+
+    """
+    from resources.lib.ipwww_common import headers as common_headers
+    requests.delete('https://user.ibl.api.bbc.co.uk/ibl/v1/user/adds/' + programme_id,
+                    headers=common_headers,
+                    cookies=GetCookieJar())
+    xbmc.executebuiltin('Container.Refresh')
 
 
 def ListRecommendations():


### PR DESCRIPTION
Re-implementation of ListFavourites() with the new feature of a context menu to remove a programme from 'Added'.

Currently ListFavourites() fails without error, resulting in 'Added' being an empty list. It looks like 'Added' suffered from the same change 'Watching' had recently.

Although it look like you can 'add' an episode on iplayer website, Added' is in fact lists of programmes. The addon presents all items as programme folder, unless the programme has only one episode, like a film. Which is pretty close to, if not the same as it was.

New is the context menu to remove the item from the 'Added' list.

**To be done:** 
To get a proper implementation of this 'Added' feature,  user's should have the possibility to add items to 'Added'. This would involve adding a context menu entry 'add programme' to all items in all listings that should support such an operation. However, if a programme is already on the 'Added' list, the context menu should an entry 'Remove' instead. All in line with current website behaviour and general user expectations.

For this to work we need:
1. The list of programme ID's that are currently on the 'Added' list.
2. Find a way to obtain programme ID's from all programmes in normal listings, and optionally for all series and episodes.
3. Create a context menu entry to add/remove from 'Added' to all items that meet the requirements.

**1) Obtaining and caching added programme ID's.**
In order to be able to know which context menu entry is to be created, the addon must know which programmes are already added before creating listings. Currently the addon is stateless. It is, of course, not feasible to request the added list each time before a page is requested, so some kind of caching should be implemented and I see several ways to do that.
-  Enable reuselanguageinvoker and simply keep the list if programmeId's in memory. That's is what I did in viwX to solve the same problem and that works fine. But enabling reuselanguageinvoker will effect other parts of the addon and that must be properly checked.
- Store data as property of a global window. I've seen this suggested on the forum several times, but it just feels very hacky to me. Still, it's easy to implement and data is available for as long Kodi is alive. Maybe it's not so bad an idea after all.
- Write and read to file, e.g. as JSON string. Involves frequent writes and might be relatively slow, in particular on systems with SD cards.
- Use an addon like SimpleCache. With the overhead that of that it is, I think, only interesting if there is a lot more to cache. Which is something to consider BTW.
All these options are easy to integrate, it's more a matter of indecision on my part as to which route to take. 

**2) Get programme ID's for all items in normal listings.**
This is where I definitely could use some help. At least all programme folders in all lists should have a context menu to add/remove them from 'Added'. I don't think users should be able to add individual episodes, as that gives the impression that you add the actual episode while in fact the whole programme is added. Unless it's a programme with a single episode of course. 
I guess that the programme ID is available in most, if not all, data, so the parser should be able to extract that. The big question is: where and for what kind of list is programme data extracted in ParseJSON(...) and ParseSingleJSON(...)? 

**3) Create the context menu.**
The appropriate place, I guess, is to handle it in AddMenuEntry(...) . If and which context menu to add can easily be established by checking the mode and the presence of a programmeID in the arguments.

Well, this is in all a much bigger story than the actual problem, but there you are. I'm very interested in your views on 1) and would very much appreciate any help or guidance on 2). And other remarks or ideas are very welcome too of course.