### PR TITLE
new categories A to Z urls.

### DIFF
--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -513,7 +513,7 @@ def ListCategoryFilters(url):
 
 def GetFilteredCategory(url):
     """Parses the programmes available in the category view."""
-    NEW_URL = 'https://www.bbc.co.uk/iplayer/categories/%s/all?sort=atoz' % url
+    NEW_URL = 'https://www.bbc.co.uk/iplayer/categories/%s/a-z' % url
 
     ScrapeEpisodes(NEW_URL)
 


### PR DESCRIPTION
A change in the way to request a-z listings, already implemented in various parts of the add-on, but apparently overlooked here.

The BBC currently returns a permanent redirect, so nothing is broken yet.