### PR TITLE
BBCiD 3 - Recommendations

### DIFF
--- a/default.py
+++ b/default.py
@@ -238,6 +238,9 @@ try:
     elif mode == 197:
         Video.ListUHDTrial()
 
+    elif mode == 198:
+        Video.ListRecommendations()
+
     # Modes 301 - 399: Context menu handlers
     elif mode == 301:
         Video.RemoveWatching(episode_id)

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -336,6 +336,10 @@ msgctxt "#30335"
 msgid "UHD Trial Channels"
 msgstr ""
 
+msgctxt "#30336"
+msgid "Recommendations"
+msgstr ""
+
 msgctxt "#30400"
 msgid "Error"
 msgstr ""
@@ -478,4 +482,8 @@ msgstr ""
 
 msgctxt "#30529"
 msgid "iPlayer: UHD Trial Channels"
+msgstr ""
+
+msgctxt "#30530"
+msgid "iPlayer: Recommendations"
 msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -487,3 +487,11 @@ msgstr ""
 msgctxt "#30530"
 msgid "iPlayer: Recommendations"
 msgstr ""
+
+msgctxt "#30600"
+msgid "View all episodes"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Remove"
+msgstr ""

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -609,6 +609,8 @@ def CreateBaseDirectory(content_type):
             AddMenuEntry(translation(30306), 'url', 107, icondir+'favourites.png', '', '')
         if ADDON.getSetting("menu_video_added") == 'true':
             AddMenuEntry(translation(30307), 'url', 108, icondir+'favourites.png', '', '')
+        if ADDON.getSetting("menu_video_recommendations") == 'true':
+            AddMenuEntry(translation(30336), 'url', 198, icondir+'top_rated.png', '', '')
         AddMenuEntry(translation(30325), 'url', 119, icondir+'settings.png',  '', '')
     elif content_type == "audio":
         if ADDON.getSetting("menu_radio_live") == 'true':
@@ -666,6 +668,9 @@ def CreateBaseDirectory(content_type):
         if ADDON.getSetting("menu_video_added") == 'true':
             AddMenuEntry((translation(30323)+translation(30307)), 'url', 108,
                          icondir+'favourites.png', '', '')
+        if ADDON.getSetting("menu_video_recommendations") == 'true':
+            AddMenuEntry(translation(30323)+translation(30336), 'url', 198,
+                         icondir+'top_rated.png', '', '')
 
         if ADDON.getSetting("menu_radio_live") == 'true':
             AddMenuEntry((translation(30324)+translation(30321)), 'url', 113,

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -824,6 +824,17 @@ def ParseJSON(programme_data, current_url):
     xbmcplugin.addSortMethod(int(sys.argv[1]), xbmcplugin.SORT_METHOD_UNSORTED)
 
 
+def SetSortMethods(*additional_methods):
+    """Set a few standard sort methods and optional additional methods"""
+    sort_methods = [xbmcplugin.SORT_METHOD_UNSORTED,
+                    xbmcplugin.SORT_METHOD_TITLE,
+                    xbmcplugin.SORT_METHOD_TITLE_IGNORE_THE]
+    sort_methods.extend(additional_methods)
+    handle = int(sys.argv[1])
+    for method in sort_methods:
+        xbmcplugin.addSortMethod(handle, method)
+
+
 def SelectSynopsis(synopses):
     if synopses is None:
         return ''

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -1066,6 +1066,25 @@ def ListFavourites():
         ParseJSON(data, url)
 
 
+def ListRecommendations():
+    data = GetJsonDataWithBBCid('https://www.bbc.co.uk/iplayer/recommendations')
+    if not data:
+        return
+    for recommended_item in data['items']['elements']:
+        episode = recommended_item['episode']
+        item_data = ParseEpisode(episode)
+        if not item_data:
+            continue
+        tleo_id = episode['tleo_id']
+        if tleo_id != episode['id']:
+            all_episodes_link = 'https://www.bbc.co.uk/iplayer/episodes/' + tleo_id
+            item_data['context_mnu'] = [
+                ('View all episodes',
+                 f'Container.Update(plugin://plugin.video.iplayerwww/?mode=128&url={all_episodes_link})')]
+        CheckAutoplay(**item_data)
+    SetSortMethods(xbmcplugin.SORT_METHOD_DATE)
+
+
 def PlayStream(name, url, iconimage, description, subtitles_url, episode_id=None, stream_id=None):
     if iconimage == '':
         iconimage = 'DefaultVideo.png'

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -1038,12 +1038,12 @@ def ListWatching():
         item_data['context_mnu'] = ct_menus = []
         if programme.get('count', 0) > 1:
             all_episodes_link = 'https://www.bbc.co.uk/iplayer/episodes/' + programme['id']
-            ct_menus.append(('View all episodes',
+            ct_menus.append((translation(30600),
                              f'Container.Update(plugin://plugin.video.iplayerwww/?mode=128&url={all_episodes_link})'))
 
         programme_id = episode.get('tleo_id')
         if programme_id:
-            ct_menus.append(('Remove',
+            ct_menus.append((translation(30601),
                              f'RunPlugin(plugin://plugin.video.iplayerwww?mode=301&episode_id={programme_id}&url=url)'))
 
         CheckAutoplay(**item_data)
@@ -1079,7 +1079,7 @@ def ListRecommendations():
         if tleo_id != episode['id']:
             all_episodes_link = 'https://www.bbc.co.uk/iplayer/episodes/' + tleo_id
             item_data['context_mnu'] = [
-                ('View all episodes',
+                (translation(30600),
                  f'Container.Update(plugin://plugin.video.iplayerwww/?mode=128&url={all_episodes_link})')]
         CheckAutoplay(**item_data)
     SetSortMethods(xbmcplugin.SORT_METHOD_DATE)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -181,6 +181,11 @@
                                     <default>true</default>
                                     <control type="toggle"/>
                                 </setting>
+                                <setting id="menu_video_recommendations" type="boolean" label="30530" help="">
+                                    <level>0</level>
+                                    <default>true</default>
+                                    <control type="toggle"/>
+                                </setting>
                                 <setting id="menu_radio_live" type="boolean" label="30522" help="">
                                     <level>0</level>
                                     <default>true</default>


### PR DESCRIPTION
Implements Recommendations. The same list as shown on the iplayer website in My Programmes -> recommendations.

Recommendations are all episodes, so are presented as playable items in the addon. Items that are part of a programme with multiple episodes have context menu 'view all episodes'.

I think this is the last item in BBCiD integration series on the video side of the addon.
Drop a note or open an issue if anyone thinks there's more BBCiD to be integrated