### PR TITLE
additional fixes #374 -  Adapt to changed episode data structure

### DIFF
--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -1032,24 +1032,31 @@ def ListWatching():
         programme = watching_item['programme']
         item_data = ParseEpisode(episode)
 
-        full_title =  item_data['name']
-        item_data['description'] = '\n\n'.join((full_title, item_data['description']))
+        # Lacking a field synopses, a watching item's description is empty. Since the
+        # remaining playtime is presented in the title instead of the usual episode name,
+        # place the original title/sub-title in the description.
+        item_data['description'] = item_data['name']
         remaining_seconds = watching_item.get('remaining')
         if remaining_seconds:
+            total_seconds = int(remaining_seconds * 100 / (100 - watching_item['progress']))
             item_data['name'] = '{} - [I]{} min left[/I]'.format(episode.get('title', ''), int(remaining_seconds / 60))
             # Resume a little bit earlier, so it's easier to recognise where you've left off.
-            item_data['resume_time'] = str(max(watching_item['progress'] - 10, 0))
+            item_data['resume_time'] = str(max(total_seconds - remaining_seconds - 10, 0))
+            item_data['total_time'] = str(total_seconds)
         else:
             item_data['name'] = '{} - [I]next episode[/I]'.format(episode.get('title', ''))
 
         item_data['context_mnu'] = ct_menus = []
-        if programme.get('count', 0) > 1:
+        programme_id = episode.get('tleo_id')
+
+        if episode.get('id') != programme_id:
+            # A programme with multiple episodes; add a 'View all episodes' context menu item.
             all_episodes_link = 'https://www.bbc.co.uk/iplayer/episodes/' + programme['id']
             ct_menus.append((translation(30600),
                              f'Container.Update(plugin://plugin.video.iplayerwww/?mode=128&url={all_episodes_link})'))
 
-        programme_id = episode.get('tleo_id')
         if programme_id:
+            # Add a context menu item 'Remove'
             ct_menus.append((translation(30601),
                              f'RunPlugin(plugin://plugin.video.iplayerwww?mode=301&episode_id={programme_id}&url=url)'))
 

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -844,18 +844,27 @@ def SelectSynopsis(synopses):
             or synopses.get('small', ''))
 
 
+def SelectImage(images):
+    if not images:
+        return 'DefaultFolder.png'
+    return(images.get('standard')
+           or images.get('promotional')
+           or images.get('promotional_with_logo')
+           or images.get('portrait', 'DefaultFolder.png')).replace('{recipe}', '832x468')
+
+
 def ParseEpisode(episode_data):
     title = episode_data.get('title', '')
     subtitle = episode_data.get('subtitle')
     if subtitle:
         title = ' - '.join((title, subtitle))
     version_data = episode_data['versions'][0]
-    description = ''.join((SelectSynopsis(episode_data.get('synopses'))))
+    description = SelectSynopsis(episode_data.get('synopses'))
 
     return {
         'url': 'https://www.bbc.co.uk/iplayer/episode/' + episode_data['id'],
         'name': title,
-        'iconimage': episode_data.get('images', {}).get('standard', 'DefaultFolder.png').replace('{recipe}', '832x468'),
+        'iconimage': SelectImage(episode_data.get('images')),
         'description': description,
         'aired': episode_data.get('release_date_time', '').split('T')[0],
         # 'total_time': str(iso_duration_2_seconds(version_data['duration']['value']))

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -841,7 +841,8 @@ def SelectSynopsis(synopses):
     return (synopses.get('editorial')
             or synopses.get('medium')
             or synopses.get('large')
-            or synopses.get('small', ''))
+            or synopses.get('small')
+            or synopses.get('programme_small', ''))
 
 
 def SelectImage(images):


### PR DESCRIPTION
Some additional changes regarding 'Watching'

- Field `progress` appears to be the progress as a percentage of the total duration, rather than the resume point in seconds.
  This PR calculates total playing time and the resume point from progress and remaining and sets Kodi properties accordingly.
- Since field `programme['count'] ` is no longer available, `episode['id']` and `episode['tleo_id']` are now used to determine whether to add a context menu 'View all episodes'. Some tests showed that on programmes with a single episode, like films or documentaries, `id` and `tleo_id` are the same, while on programmes with multiple episodes they differ.

Other changes:

- While testing I noticed that `images['standard']` is sometimes not available while other types of images are. Function `SelectImage()` is added to ensure an image is used whenever available.
- In some tests I noticed a (to me) new type of synopsis, which is added to `SelectSynopsis()`.
