### PR TITLE
watch live programme from the start

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -4,6 +4,8 @@
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.requests" version="2.7.0"/>
     <import addon="inputstream.adaptive" version="2.6.0"/>
+    <import addon="script.module.pytz"/>
+    <import addon="script.module.tzlocal"/>
     <import addon="resource.images.iplayerwww" version="1.0.0"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="default.py">

--- a/default.py
+++ b/default.py
@@ -91,6 +91,9 @@ episode_id = Common.utf8_unquote_plus(params.get('episode_id', ''))
 stream_id = Common.utf8_unquote_plus(params.get('stream_id', ''))
 resume_time = params.get('resume_time', '')
 total_time = params.get('total_time', '')
+watch_from_start = params.get('watch_from_start') == 'True'
+replay_chan_id = params.get('replay_chan_id', '')
+
 
 try:
     # These are the modes which tell the plugin where to go.
@@ -166,7 +169,7 @@ try:
         Video.GetAvailableStreams(name, url, iconimage, description, resume_time, total_time)
 
     elif mode == 123:
-        Video.AddAvailableLiveStreamsDirectory(name, url, iconimage)
+        Video.AddAvailableLiveStreamsDirectory(name, url, iconimage, watch_from_start)
 
     elif mode == 124:
         Video.GetAtoZPage(url)
@@ -212,13 +215,13 @@ try:
 
     # Modes 201-299 will create a playable menu entry, not a directory
     elif mode == 201:
-        Video.PlayStream(name, url, iconimage, description, subtitles_url, episode_id, stream_id)
+        Video.PlayStream(name, url, iconimage, description, subtitles_url, episode_id, stream_id, replay_chan_id)
 
     elif mode == 202:
         Video.AddAvailableStreamItem(name, url, iconimage, description)
 
     elif mode == 203:
-        Video.AddAvailableLiveStreamItemSelector(name, url, iconimage)
+        Video.AddAvailableLiveStreamItemSelector(name, url, iconimage, watch_from_start)
 
     elif mode == 204:
         Video.AddAvailableRedButtonItem(name, url)

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -400,6 +400,22 @@ msgctxt "#30414"
 msgid "This BBC Sounds programme is available to play in the UK only."
 msgstr ""
 
+msgctxt "#30415"
+msgid "The start position of the current programme is not available.\nPlaying live now."
+msgstr ""
+
+msgctxt "#30416"
+msgid "This programme started too long ago and cannot be played from the start anymore."
+msgstr ""
+
+msgctxt "#30417"
+msgid "Play from 2 hours back"
+msgstr ""
+
+msgctxt "#30418"
+msgid "Play live"
+msgstr ""
+
 msgctxt "#30500"
 msgid "Display"
 msgstr ""
@@ -494,4 +510,8 @@ msgstr ""
 
 msgctxt "#30601"
 msgid "Remove"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Watch from the start"
 msgstr ""

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -3,6 +3,8 @@
 import sys
 import os
 import re
+from datetime import datetime
+
 import requests
 from requests.packages import urllib3
 #Below is required to get around an ssl issue
@@ -432,6 +434,11 @@ def utf8_quote_plus(unicode):
 # Gets a unicode string from a 'urlencoded' string
 def utf8_unquote_plus(str):
     return urllib.parse.unquote_plus(str)
+
+
+def strptime(dt_str: str, format: str):
+    """A bug free alternative to `datetime.datetime.strptime(...)`"""
+    return datetime(*(time.strptime(dt_str, format)[0:6]))
 
 
 def iso_duration_2_seconds(iso_str: str) -> int:

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -436,11 +436,6 @@ def utf8_unquote_plus(str):
     return urllib.parse.unquote_plus(str)
 
 
-def strptime(dt_str: str, format: str):
-    """A bug free alternative to `datetime.datetime.strptime(...)`"""
-    return datetime(*(time.strptime(dt_str, format)[0:6]))
-
-
 def iso_duration_2_seconds(iso_str: str) -> int:
     """Convert an ISO 8601 duration string into seconds.
 
@@ -460,8 +455,13 @@ def iso_duration_2_seconds(iso_str: str) -> int:
     return None
 
 
-def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=None, resolution=None,
-                 resume_time='', total_time='', episode_id='', stream_id='', context_mnu=None):
+def strptime(dt_str: str, format: str):
+    """A bug free alternative to `datetime.datetime.strptime(...)`"""
+    return datetime(*(time.strptime(dt_str, format)[0:6]))
+
+
+def AddMenuEntry(name, url, mode, iconimage, description='', subtitles_url='', aired=None, resolution=None,
+                 resume_time='', total_time='', episode_id='', stream_id='', context_mnu=None, replay_chan_id=''):
     """Adds a new line to the Kodi list of playables.
     It is used in multiple ways in the plugin, which are distinguished by modes.
     """
@@ -479,7 +479,8 @@ def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=N
         "&episode_id=", utf8_quote_plus(episode_id),
         "&stream_id=", utf8_quote_plus(stream_id),
         "&resume_time=", resume_time,
-        "&total_time=", total_time))
+        "&total_time=", total_time,
+        "&replay_chan_id=", replay_chan_id))
     if mode in (101,203,113,213):
         listitem_url = listitem_url + "&time=" + str(time.time())
     if aired:
@@ -552,6 +553,7 @@ def AddMenuEntry(name, url, mode, iconimage, description, subtitles_url, aired=N
                                 url=listitem_url, listitem=listitem, isFolder=isFolder)
     xbmcplugin.setContent(int(sys.argv[1]), 'episodes')
     return True
+
 
 def KidsMode():
     dialog = xbmcgui.Dialog()

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -175,6 +175,8 @@ def ListLive():
             AddMenuEntry(title, id, 203, iconimage, schedule, '')
         else:
             AddMenuEntry(title, id, 123, iconimage, schedule, '')
+    xbmcplugin.endOfDirectory(int(sys.argv[1]), cacheToDisc=False)
+    sys.exit()
 
 
 def ListAtoZ():

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -185,9 +185,10 @@ def ListLive():
                                  'iconimage': iconimage,
                                  'watch_from_start': 'True'})
         ctx_mnu = [(translation(30603),     # 'Watch from the start'
-                    ''.join((restart_action, '(plugin://', addonid, '?', querystring, ')'))
+                    ''.join((restart_action, '(plugin://', addonid, '?', querystring,
+                             ', noresume)' if mode == 203 else ')'))
                     )]
-        AddMenuEntry(title, id, mode, iconimage, schedule, '', context_mnu=ctx_mnu)
+        AddMenuEntry(title, id, mode, iconimage, schedule, '', resume_time='0', context_mnu=ctx_mnu)
     xbmcplugin.endOfDirectory(int(sys.argv[1]), cacheToDisc=False)
     sys.exit()
 
@@ -1007,15 +1008,16 @@ def AddAvailableLiveStreamsDirectory(name, channelname, iconimage, watch_from_st
         name: only used for displaying the channel.
         iconimage: only used for displaying the channel.
         channelname: determines which channel is queried.
+        watch_from_start: True if the current programme is to be played from the start.
     """
     streams = ParseLiveDASHStreams(channelname)
     suppliers = ['', 'Akamai', 'Limelight', 'Bidi','Cloudfront']
     for supplier, bitrate, url, resolution in streams:
         title = name + ' - [I][COLOR fff1f1f1]%s[/COLOR][/I]' % (suppliers[supplier])
         if watch_from_start:
-            AddMenuEntry(title, url, 201, iconimage, '', '', replay_chan_id=channelname)
+            AddMenuEntry(title, url, 201, iconimage, resume_time='0', replay_chan_id=channelname)
         else:
-            AddMenuEntry(title, url, 201, iconimage, '', '')
+            AddMenuEntry(title, url, 201, iconimage, resume_time='0')
 
 
 def GetJsonDataWithBBCid(url, retry=True):
@@ -1108,7 +1110,7 @@ def ListRecommendations():
     SetSortMethods(xbmcplugin.SORT_METHOD_DATE)
 
 
-def PlayStream(name, url, iconimage, description, subtitles_url, episode_id=None, stream_id=None, replay_chan_id=''):
+def PlayStream(name, url, iconimage, description='', subtitles_url='', episode_id=None, stream_id=None, replay_chan_id=''):
     if iconimage == '':
         iconimage = 'DefaultVideo.png'
     html = OpenURL(url)


### PR DESCRIPTION
Added a feature to watch the current live show from the start. 
Fixes #49 

The feature is available from the context menu on all channels in 'Watch Live'.
Both automatic and manual stream selection are supported.

Principle of operation:
 - Request the start time of the current programme from the BBC
 - Direct Inputstream Adaptive to play from the start of the timeshift window instead of the live edge.
 - Calculate the start of the current programme relative to the start of the timeshift window
 - Direct Kodi to resume from there.

If a show started more than 2 hours ago (the size of the replay window) a dialog will be shown asking the user to either start from 2 hours back or play live.

As 'watch from the start' has little value when you don't know what's on and for how long, the current programme name is added to the channel's name in the live listing and the schedule of the next 12 programmes is made available the channel's description. The number of 12 programmes is an arbitrary number. The intention was that early evening a user would be able check what's on late at night.

AFAIK regional BBC one channels only differ in their regional news. In order to greatly reduce the number of requests to be made, only the schedule of BBC One London is requested. London's regional new is renamed to 'News where you are', and it's schedule is applied to all BBC One channels. It would be nice if someone could confirm that this is a correct assessment.
Schedules are presented it the user's local time zone and in the user's regional time format.

This PR adds a dependency on pytz to convert UTC schedules to the user's time zone.
It also adds a dependency on tzlocal to support this on Matrix. The module tzlocal is only imported when obtaining timezone info from Kodi fails.
