### PR TITLE
Update Continue Watching.

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -217,7 +217,7 @@ msgid "Watch Live"
 msgstr ""
 
 msgctxt "#30306"
-msgid "Watching"
+msgid "Continue Watching"
 msgstr ""
 
 msgctxt "#30307"
@@ -461,7 +461,7 @@ msgid "iPlayer: Red Button"
 msgstr ""
 
 msgctxt "#30520"
-msgid "iPlayer: Watching"
+msgid "iPlayer: Continue Watching"
 msgstr ""
 
 msgctxt "#30521"

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -1050,7 +1050,7 @@ def GetJsonDataWithBBCid(url, retry=True):
 
 
 def ListWatching():
-    url = "https://www.bbc.co.uk/iplayer/watching"
+    url = "https://www.bbc.co.uk/iplayer/continue-watching"
     data = GetJsonDataWithBBCid(url)
     if not data:
         return
@@ -1066,7 +1066,7 @@ def ListWatching():
         item_data['description'] = item_data['name']
         remaining_seconds = watching_item.get('remaining')
         if remaining_seconds:
-            total_seconds = int(remaining_seconds * 100 / (100 - watching_item['progress']))
+            total_seconds = int(remaining_seconds * 100 / (100 - watching_item.get('progress', 0)))
             item_data['name'] = '{} - [I]{} min left[/I]'.format(episode.get('title', ''), int(remaining_seconds / 60))
             # Resume a little bit earlier, so it's easier to recognise where you've left off.
             item_data['resume_time'] = str(max(total_seconds - remaining_seconds - 10, 0))


### PR DESCRIPTION
Renamed 'Watching' to Continue Watching' to align with terminology used on the website. 
Allow the absence of field 'progress'.

Fixes the rather rare issue that field progress is missing on data that is marked 'current', i.e. an episode that can be continued. It smells like a bug on bbc's site of things, but this PR ensures the list will not fail. 

Judging by [this post](https://github.com/vonH/plugin.video.iplayerwww/issues/374#issuecomment-2168284990) it may not be that rare after all.