### PR TITLE
Set a timeout on HTTP(S) requests.

### DIFF
--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -366,16 +366,17 @@ def OpenRequest(method, url, *args, **kwargs):
         session.cookies = cookie_jar
         session.headers = headers
         exit_on_error = kwargs.pop('exit_on_error', False)
+        kwargs.setdefault('timeout', (4, 10))
         try:
             resp = session.request(method, url, *args, **kwargs)
             resp.raise_for_status()
         except requests.exceptions.RequestException as e:
+            xbmc.log(f"'{method}' request to '{url}' failed: {e!r}")
             if exit_on_error:
                 dialog = xbmcgui.Dialog()
                 dialog.ok(translation(30400), "%s" % e)
                 sys.exit(1)
             else:
-                xbmc.log(f"'{method}' request to '{url}' failed: {e!r}")
                 raise
         try:
             # Set ignore_discard to overcome issue of not having session


### PR DESCRIPTION
Prevents very long timeouts when some network issue prevents urilb3 to connect, which can make Kodi seem unresponsive for several minutes.
