### PR TITLE
Properly handle request exceptions.

### DIFF
--- a/default.py
+++ b/default.py
@@ -251,7 +251,7 @@ try:
     elif mode == 302:
         Video.RemoveFavourite(episode_id)
 
-except Common.IpwwwError as err:
+except Exception as err:
     xbmcgui.Dialog().ok(Common.translation(30400), str(err))
     sys.exit(1)
 

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -37,6 +37,13 @@ class GeoBlockedError(IpwwwError):
     pass
 
 
+class WebRequestError(IpwwwError):
+    def __init__(self, err_msg, response):
+        self.status_code = response.status_code
+        self.content = response.content
+        super().__init__(err_msg)
+
+
 def tp(path):
     return xbmcvfs.translatePath(path)
 
@@ -365,27 +372,20 @@ def OpenRequest(method, url, *args, **kwargs):
     with requests.Session() as session:
         session.cookies = cookie_jar
         session.headers = headers
-        exit_on_error = kwargs.pop('exit_on_error', False)
         try:
             resp = session.request(method, url, *args, **kwargs)
-            if resp.status_code == 404:
-                return ""
-            else:
-                resp.raise_for_status()
+            resp.raise_for_status()
         except requests.exceptions.RequestException as e:
-            if exit_on_error:
-                dialog = xbmcgui.Dialog()
-                dialog.ok(translation(30400), "%s" % e)
-                sys.exit(1)
-            else:
-                xbmc.log(f"'{method}' request to '{url}' failed: {e!r}")
-                raise
+            xbmc.log(f"'{method}' request to '{url}' failed: {e!r}")
+            if isinstance(e, requests.HTTPError):
+                e = WebRequestError(str(e), e.response)
+            raise e
         try:
-            # Set ignore_discard to overcome issue of not having session
-            # as cookie_jar is reinitialised for each action.
             # Refreshed token cookies are set on intermediate requests.
             # Only save if there have been any.
             if resp.history:
+                # Set ignore_discard to overcome issue of not having session
+                # as cookie_jar is reinitialised for each action.
                 cookie_jar.save(ignore_discard=True)
         except:
             pass
@@ -393,7 +393,7 @@ def OpenRequest(method, url, *args, **kwargs):
 
 
 def OpenURL(url):
-    r = OpenRequest('get', url, exit_on_error=True)
+    r = OpenRequest('get', url)
     return unescape(r)
 
 
@@ -427,13 +427,8 @@ def DeleteUrl(url, **kwargs):
     with requests.Session() as session:
         session.cookies = cookie_jar
         session.headers = headers
-        try:
-            r = session.delete(url, **kwargs)
-            r.raise_for_status()
-        except requests.exceptions.RequestException as e:
-            dialog = xbmcgui.Dialog()
-            dialog.ok(translation(30400), "%s" % e)
-            sys.exit(1)
+        r = session.delete(url, **kwargs)
+        r.raise_for_status()
         try:
             if r.history:
                 cookie_jar.save(ignore_discard=True)
@@ -442,7 +437,7 @@ def DeleteUrl(url, **kwargs):
 
 
 def PostJson(url, data):
-    return OpenRequest('post', url, json=data, exit_on_error=True)
+    return OpenRequest('post', url, json=data)
 
 
 def GetCookieJar():

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -12,11 +12,10 @@ import json
 from datetime import timedelta
 from operator import itemgetter
 
-from resources.lib.ipwww_common import translation, AddMenuEntry, OpenURL, OpenRequest, \
-                                       CheckLogin, CreateBaseDirectory, GetCookieJar, \
-                                       ParseImageUrl, download_subtitles, GeoBlockedError, \
-                                       iso_duration_2_seconds, PostJson, strptime, addonid, DeleteUrl, \
-                                       ProgressDlg
+from resources.lib.ipwww_common import (
+    translation, AddMenuEntry, OpenURL, OpenRequest, CheckLogin, CreateBaseDirectory,
+    GetCookieJar, ParseImageUrl, download_subtitles, GeoBlockedError, WebRequestError,
+    iso_duration_2_seconds, PostJson, strptime, addonid, DeleteUrl, ProgressDlg)
 from resources.lib import ipwww_progress
 
 import xbmc
@@ -258,7 +257,14 @@ def GetAtoZPage(url):
 def GetSingleAtoZPage(url, pDialog=None):
     current_url = 'https://www.bbc.co.uk/iplayer/a-z/%s' % url
     # print("Opening "+current_url)
-    html = OpenURL(current_url)
+    try:
+        html = OpenURL(current_url)
+    except WebRequestError as err:
+        # Ignore missing pages; there are simply no programmes starting with this letter.
+        if err.status_code == 404:
+            return
+        else:
+            raise
 
     total_pages = 1
     current_page = 1


### PR DESCRIPTION
Exceptions in web requests no longer exit the interpreter by default. Exceptions now bubble up, like exceptions are intended, to be handled by any calling code whenever and wherever required.

This cleans up that rather hacky `exit_on_error` parameter of `OpenRequest()` and allows response handling code to access HTTP status codes more easily. Like now done with missing A-Z pages (#384 )
