### PR TITLE
Fix: watchlist fails when one-off programmes are on the list.

### DIFF
--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -1123,7 +1123,7 @@ def RemoveWatching(episode_id):
 
 def ListFavourites():
     """AKA 'Watchlist', FKA 'Added'."""
-    data = GetJsonDataWithBBCid("https://www.bbc.co.uk/iplayer/added")
+    data = GetJsonDataWithBBCid("https://www.bbc.co.uk/iplayer/watchlist")
     if not data:
         return
 


### PR DESCRIPTION
Watchlist failed when programmes were on the list that do not have multiple episodes, like films, special broadcasts, or some documentaries 
fixes #387 