### PR TITLE
Fix: Cannot watch BBC-One from the start

### DIFF
--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -1201,9 +1201,11 @@ def GetLiveStartPosition(chan_id):
 
     from datetime import datetime, timezone
 
-    # Apart from bbc_one_hd, schedules from HD channels must be requested by their non-HD counterpart.
-    if chan_id.endswith('_hd') and not chan_id.startswith('bbc_one'):
+    # Schedules from HD channels must be requested by their non-HD counterpart.
+    if chan_id.endswith('_hd'):
         chan_id = chan_id[:-3]
+    if chan_id == 'bbc_one':
+        chan_id = 'bbc_one_london'
 
     now = datetime.now(timezone.utc)
     resp = None


### PR DESCRIPTION
Schedule data of bbc-one-hd does not contain the actual schedule anymore.
As a consequence 'watch from the start' almost always complained that the programme started too long ago.
Now using the schedule of bbc one london.