### PR TITLE
log all unhandled exceptions

### DIFF
--- a/default.py
+++ b/default.py
@@ -252,7 +252,9 @@ try:
         Video.RemoveFavourite(episode_id)
 
 except Exception as err:
+    import traceback
     xbmcgui.Dialog().ok(Common.translation(30400), str(err))
+    xbmc.log('[ipwww.default][error] ' + traceback.format_exc())
     sys.exit(1)
 
 xbmcplugin.endOfDirectory(int(sys.argv[1]))


### PR DESCRIPTION
Because we catch all exceptions since #386 we must now also take care ourselves to write some info to the log.