### PR TITLE
Fix: live and red-button items in programmes listings.

### DIFF
--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -1336,6 +1336,11 @@ def ParseDASHStreams(stream_id):
             streams.append((tmp_sup, 1, url, '1280x720', protocol))
     source = int(ADDON.getSetting('subtitle_source'))
     for href, protocol, supplier in mediaselector[1]:
+        if '$Number$' in href:
+            # Found in live and red-button streams and requires `$Number$` to be replaced by
+            # a DASH segment id.
+            # Since DASH is handled by Inputstream Adaptive, live subtitles are not supported.
+            continue
         if 'akamai' in supplier and source in [0,1]:
             tmp_sup = 1
         elif 'limelight' in supplier and source in [0,2]:
@@ -1422,6 +1427,9 @@ def ScrapeAvailableStreams(url):
             elif (stream['kind'] == 'webcast'):
                 st.append(stream['id'])
                 ty.append(2)
+            elif (stream['kind'] == 'simulcast'):
+                st.append(stream['serviceId'])
+                ty.append(0)
             elif (stream['kind'] == 'signed'):
                 stream_id_sl = stream['id']
             elif (stream['kind'] == 'audio-described'):


### PR DESCRIPTION
Fixes the issue that some live items listed as episode fail to play.

The listings of some special events include items representing various types of live streams. At the moment of this writing category Sport -> Snooker: UK Championships includes a folder 'Live Now' containing several live streams. 

Some items are of type webcast, AKA sport stream, which already play fine on Kodi 21+ (or rather Inputstream Adaptive 21+).

Other items represent either the live stream of one of BBC's main channels, or the red-button stream, but these failed to play. 
This PR provides a small fix and these streams play on Kodi 19 (Matrix) and above.