### PR TITLE
Add search history.

### DIFF
--- a/default.py
+++ b/default.py
@@ -114,7 +114,8 @@ try:
         Video.ListCategories()
 
     elif mode == 104:
-        Video.Search(keyword)
+        from resources.lib.ipwww_search import list_search_terms
+        list_search_terms(url, 130 if url == 'video' else 140)
 
     elif mode == 105:
         Video.ListMostPopular()
@@ -139,9 +140,6 @@ try:
 
     elif mode == 114:
         Radio.ListGenres()
-
-    elif mode == 115:
-        Radio.Search(keyword)
 
     elif mode == 116:
         Radio.ListMostPopular()
@@ -189,6 +187,9 @@ try:
     elif mode == 129:
         Video.AddAvailableRedButtonDirectory(name, url)
 
+    elif mode == 130:
+        Video.Search(url)
+
     elif mode == 131:
         Radio.GetEpisodes(url)
 
@@ -212,6 +213,13 @@ try:
 
     elif mode == 139:
         Video.ScrapeEpisodes(url)
+
+    elif mode == 140:
+        Radio.Search(url)
+
+    elif mode == 190:
+        from resources.lib.ipwww_search import new_search
+        new_search(content_type=url, mode=130 if url == 'video' else 140)
 
     # Modes 201-299 will create a playable menu entry, not a directory
     elif mode == 201:
@@ -250,6 +258,13 @@ try:
 
     elif mode == 302:
         Video.RemoveFavourite(episode_id)
+
+    # Reserved mode 303 for AddFavourite
+
+    elif mode == 304:
+        from resources.lib.ipwww_search import context_menu
+        context_menu(content_type, url, keyword)
+
 
 except Exception as err:
     import traceback

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -515,3 +515,11 @@ msgstr ""
 msgctxt "#30603"
 msgid "Watch from the start"
 msgstr ""
+
+msgctxt "#30604"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Clear search history"
+msgstr ""

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -512,8 +512,8 @@ def AddMenuEntry(name, url, mode, iconimage, description='', subtitles_url='', a
     # Modes 201-299 will create a new playable line, otherwise create a new directory line.
     if mode in (201, 202, 203, 204, 205, 211, 212, 213, 214):
         isFolder = False
-    # Mode 119 is not a folder, but it is also not a playable.
-    elif mode == 119:
+    # Modes 119 (sign out) and 190 (new search) are not folders, but are also not playable.
+    elif mode in (119, 190):
         isFolder = False
     else:
         isFolder = True
@@ -562,8 +562,8 @@ def AddMenuEntry(name, url, mode, iconimage, description='', subtitles_url='', a
         listitem.setProperty('inputstream', 'inputstream.adaptive')
         listitem.setProperty('inputstream.adaptive.manifest_type', 'mpd')
 
-    # Mode 119 is not a folder, but it is also not a playable.
-    if mode == 119:
+    # Modes 119 (sign out) and 190 (new search) are not folders, but also not playable.
+    if mode in (119, 190):
         listitem.setProperty("IsPlayable", 'false')
     else:
         listitem.setProperty("IsPlayable", str(not isFolder).lower())
@@ -627,7 +627,7 @@ def CreateBaseDirectory(content_type):
         if ADDON.getSetting("menu_video_categories") == 'true':
             AddMenuEntry(translation(30303), 'url', 103, icondir+'lists.png', '', '')
         if ADDON.getSetting("menu_video_search") == 'true':
-            AddMenuEntry(translation(30304), 'url', 104, icondir+'search.png', '', '')
+            AddMenuEntry(translation(30304), 'video', 104, icondir+'search.png', '', '')
         if ADDON.getSetting("menu_video_live") == 'true':
             AddMenuEntry(translation(30305), 'url', 101, icondir+'tv.png', '', '')
         # if ADDON.getSetting("menu_video_red_button") == 'true':
@@ -649,7 +649,7 @@ def CreateBaseDirectory(content_type):
         if ADDON.getSetting("menu_radio_categories") == 'true':
             AddMenuEntry(translation(30303), 'url', 114, icondir+'lists.png', '', '')
         if ADDON.getSetting("menu_radio_search") == 'true':
-            AddMenuEntry(translation(30304), 'url', 115, icondir+'search.png', '', '')
+            AddMenuEntry(translation(30304), 'audio', 104, icondir+'search.png', '', '')
         if ADDON.getSetting("menu_radio_most_popular") == 'true':
             AddMenuEntry(translation(30301), 'url', 116, icondir+'popular.png', '', '')
         if ADDON.getSetting("menu_radio_added") == 'true':
@@ -680,7 +680,7 @@ def CreateBaseDirectory(content_type):
             AddMenuEntry((translation(30323)+translation(30303)), 'url', 103,
                          icondir+'lists.png', '', '')
         if ADDON.getSetting("menu_video_search") == 'true':
-            AddMenuEntry((translation(30323)+translation(30304)), 'url', 104,
+            AddMenuEntry((translation(30323)+translation(30304)), 'video', 104,
                          icondir+'search.png', '', '')
         if ADDON.getSetting("menu_video_live") == 'true':
             AddMenuEntry((translation(30323)+translation(30305)), 'url', 101,
@@ -711,7 +711,7 @@ def CreateBaseDirectory(content_type):
             AddMenuEntry((translation(30324)+translation(30303)), 'url', 114,
                          icondir+'lists.png', '', '')
         if ADDON.getSetting("menu_radio_search") == 'true':
-            AddMenuEntry((translation(30324)+translation(30304)), 'url', 115,
+            AddMenuEntry((translation(30324)+translation(30304)), 'audio', 104,
                          icondir+'search.png', '', '')
         if ADDON.getSetting("menu_radio_most_popular") == 'true':
             AddMenuEntry((translation(30324)+translation(30301)), 'url', 116,
@@ -736,3 +736,4 @@ class ProgressDlg(xbmcgui.DialogProgressBG):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
+

--- a/resources/lib/ipwww_radio.py
+++ b/resources/lib/ipwww_radio.py
@@ -732,13 +732,7 @@ def ListMostPopular():
 
 def Search(search_entered):
     """Simply calls the online search function. The search is then evaluated in EvaluateSearch."""
-    if search_entered is None:
-        keyboard = xbmc.Keyboard('', 'Search iPlayer')
-        keyboard.doModal()
-        if keyboard.isConfirmed():
-            search_entered = keyboard.getText()
-
-    if search_entered is None:
+    if not search_entered:
         return False
 
     url = 'https://www.bbc.co.uk/sounds/search?q=%s' % search_entered

--- a/resources/lib/ipwww_search.py
+++ b/resources/lib/ipwww_search.py
@@ -1,0 +1,165 @@
+
+import os
+import json
+
+import xbmc
+
+from resources.lib.ipwww_common import (
+    translation,
+    DIR_USERDATA,
+    AddMenuEntry,
+    icondir)
+
+
+class SearchHistory:
+    """
+    A class providing an easy interface to saved search terms.
+
+    :param content_type: The media type of the search terms, either `video`, for iplayer
+        keywords, or `audio` for sounds.
+    """
+
+    def __init__(self, content_type: str):
+        self.full_path = os.path.join(DIR_USERDATA, 'search_terms.json')
+        if content_type not in ('video', 'audio'):
+            raise ValueError(f"Invalid content_type '{content_type}' for SearchHistory. "
+                             "Only 'video' and 'audio' are allowed.")
+        self.content_type = content_type
+        file_content = self._read_file()
+        self._keywords_list = file_content.setdefault(content_type, [])
+
+    def _read_file(self):
+        try:
+            with open(self.full_path, 'r', encoding='utf8') as f:
+                data = json.load(f)
+                return data
+        except (OSError, KeyError, TypeError):
+            return {}
+
+    def _save_file(self):
+        # dumps first, so as not to overwrite existing data on json errors.
+        _file_content = self._read_file()
+        _file_content[self.content_type] = self._keywords_list
+        new_data = json.dumps(_file_content)
+        with open(self.full_path, 'w', encoding='utf8') as f:
+            f.write(new_data)
+
+    def append(self, keyword: str):
+        """Add `term` to the saved search terms for the specified media type.
+
+        :param keyword: The search term to save.
+
+        """
+        xbmc.log(f"[ipwww_search] Adding new search term '{keyword}' to {self.content_type} list")
+        if not keyword or keyword in self._keywords_list:
+            return
+        self._keywords_list.insert(0, keyword)
+        self._save_file()
+
+    def remove(self, keyword: str):
+        """Remove `term` from the saved search terms for the specified media type.
+        Fails silently when `term` does not exist in the search history.
+
+        :param keyword: The search term to remove.
+
+        """
+        xbmc.log(f"[ipwww_search] Removing search term '{keyword}' from the {self.content_type} list")
+        if keyword not in self._keywords_list:
+            return
+        self._keywords_list.remove(keyword)
+        self._save_file()
+
+    def clear(self):
+        """Remove al search terms."""
+        xbmc.log(f"[ipwww_search] Clear search history of {self.content_type}.")
+        self._keywords_list.clear()
+        self._save_file()
+
+    def replace(self, existing: str, new: str):
+        """Replace an existing keyword with a new one.
+
+        :param existing: The existing keyword to replace.
+        :param new: The new keyword that will replace the existing.
+        :raises: ValueError if `existing` is not present in the search history
+        """
+        xbmc.log(f"[ipwww_search] Replacing search term '{existing}' for {new} in the {self.content_type} list")
+        idx = self._keywords_list.index(existing)
+        self._keywords_list[idx] = new
+        self._save_file()
+
+    def __bool__(self):
+        return bool(self._keywords_list)
+
+    def __iter__(self):
+        return iter(self._keywords_list)
+
+
+def open_keyboard(content_type):
+    heading = ' - '.join((translation(30304), 'iPlayer' if content_type == 'video' else 'Sounds'))
+    keyboard = xbmc.Keyboard('', heading)
+    keyboard.doModal()
+    if keyboard.isConfirmed():
+        return keyboard.getText()
+    else:
+        return ''
+
+
+def list_search_terms(content_type: str, mode: int):
+    """Create a listing of saved search terms, starting with an item that enables users
+    to enter a new search term using the on-screen keyboard.
+
+    :param content_type: The media type of the search terms, either `video`, for iplayer
+        searches, or `audio` for sounds.
+    :param mode: The mode to define the callback that is to perform the actual search.
+    """
+    icon = icondir + 'search.png'
+    search_history = SearchHistory(content_type)
+    txt_remove = translation(30601)
+    txt_edit = translation(30604)
+    txt_clear = translation(30605)
+
+    AddMenuEntry('New Search', url=content_type, mode=190, iconimage=icon)
+    for keyword in search_history:
+        ctx_mnu = [(txt_remove,
+                    'RunPlugin(plugin://plugin.video.iplayerwww?'
+                    f'mode=304&content_type={content_type}&url=remove&keyword={keyword})'),
+                   (txt_edit,
+                    'RunPlugin(plugin://plugin.video.iplayerwww?'
+                    f'mode=304&content_type={content_type}&url=edit&keyword={keyword})'),
+                   (txt_clear,
+                    'RunPlugin(plugin://plugin.video.iplayerwww?'
+                    f'mode=304&content_type={content_type}&url=clear)')
+                   ]
+        AddMenuEntry(keyword, keyword, mode, icon, context_mnu=ctx_mnu)
+
+
+def new_search(content_type, mode):
+    keyword = open_keyboard(content_type)
+    if keyword:
+        SearchHistory(content_type).append(keyword)
+        xbmc.executebuiltin(f'Container.Update(plugin://plugin.video.iplayerwww?mode={mode}&url={keyword})')
+
+
+def context_menu(content_type: str, action: str, keyword: str = None):
+    """Handle all search related context menu items."""
+    search_history = SearchHistory(content_type)
+
+    if action == 'remove':
+        search_history.remove(keyword)
+    elif action == 'clear':
+        search_history.clear()
+    elif action == 'edit':
+        heading = ' - '.join((translation(30604), keyword))
+        keyboard = xbmc.Keyboard(keyword, heading)
+        keyboard.doModal()
+        if not keyboard.isConfirmed():
+            return
+
+        new_term = keyboard.getText()
+        if new_term == '':
+            search_history.remove(keyword)
+        else:
+            search_history.replace(keyword, new_term)
+    else:
+        xbmc.log(f"[ipwww_search] Invalid context menu action '{action}'.")
+    xbmc.executebuiltin('Container.Refresh')

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -15,7 +15,7 @@ from operator import itemgetter
 from resources.lib.ipwww_common import (
     translation, AddMenuEntry, OpenURL, OpenRequest, CheckLogin, CreateBaseDirectory,
     GetCookieJar, ParseImageUrl, download_subtitles, GeoBlockedError, WebRequestError,
-    iso_duration_2_seconds, PostJson, strptime, addonid, DeleteUrl, ProgressDlg)
+    iso_duration_2_seconds, PostJson, strptime, addonid, DeleteUrl, ProgressDlg, utf8_quote_plus)
 from resources.lib import ipwww_progress
 
 import xbmc
@@ -1023,16 +1023,10 @@ def GetAvailableStreams(name, url, iconimage, description, resume_time='', total
 
 def Search(search_entered):
     """Simply calls the online search function. The search is then evaluated in EvaluateSearch."""
-    if search_entered is None:
-        keyboard = xbmc.Keyboard('', 'Search iPlayer')
-        keyboard.doModal()
-        if keyboard.isConfirmed():
-            search_entered = keyboard.getText() .replace(' ', '%20')  # sometimes you need to replace spaces with + or %20
-
-    if search_entered is None:
+    if not search_entered:
         return False
 
-    NEW_URL = 'https://www.bbc.co.uk/iplayer/search?q=%s' % search_entered
+    NEW_URL = 'https://www.bbc.co.uk/iplayer/search?q=%s' % utf8_quote_plus(search_entered)
     ScrapeEpisodes(NEW_URL)
 
 


### PR DESCRIPTION
Fixes #3 and #393

Menu 'Search' now shows a new page. The first item allows one to enter a new search term, and is followed by a list of previously entered search terms (if any). 
All search terms have a context menu with items to remove or edit the search term, or to clear the whole list.

Keyboard entry is now implemented in such a way that the keyboard won't show up again after a search result has been played, or when navigating back from search results.

iPLayer and Radio have their own separate search history. 
Search history is implemented on radio, but radio's web search requires some serious rework and does not work at the moment. But that's for another day.