### PR TITLE
Support 2160p/1080p VOD and support 1080p live streams

### DIFF
--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -6,6 +6,8 @@ import re
 from datetime import datetime
 
 import requests
+import ssl
+from requests.adapters import HTTPAdapter
 from requests.packages import urllib3
 #Below is required to get around an ssl issue
 urllib3.disable_warnings()
@@ -71,7 +73,7 @@ icondir = 'resource://resource.images.iplayerwww/media/'
 cookie_jar = None
 user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:130.0) Gecko/20100101 Firefox/130.0'
 headers = {'User-Agent': user_agent}
-
+secure_mediators = ['securegate.iplayer.bbc.co.uk', 'ipsecure.stage.bbc.co.uk']
 
 if(not os.path.exists(DIR_USERDATA)):
     os.makedirs(DIR_USERDATA)
@@ -368,12 +370,40 @@ def CheckLogin():
     return False
 
 
+def GetBBCiPlayerPemPath():
+    pem_file_name = 'bbciplayer.pem'
+    for dir in [addoninfo["path"], DIR_USERDATA]:
+        pem_path = os.path.join(dir, pem_file_name)
+        if os.path.exists(pem_path):
+            return pem_path
+    return None
+
+class SecLevel0SSLAdapter(HTTPAdapter):
+    _shared_ssl_context = ssl.create_default_context()
+    # SECLEVEL 1 does not suppress CA_MD_TOO_WEAK on some devices
+    _shared_ssl_context.set_ciphers("DEFAULT:@SECLEVEL=0")
+
+    def init_poolmanager(self, connections, maxsize, block=False, **kwargs):
+        kwargs['ssl_context'] = self._shared_ssl_context
+        return super().init_poolmanager(connections, maxsize, block=block, **kwargs)
+
+    def proxy_manager_for(self, *args, **kwargs):
+        kwargs['ssl_context'] = self._shared_ssl_context
+        return super().proxy_manager_for(*args, **kwargs)
+
 def OpenRequest(method, url, *args, **kwargs):
     with requests.Session() as session:
         session.cookies = cookie_jar
         session.headers = headers
         exit_on_error = kwargs.pop('exit_on_error', False)
         kwargs.setdefault('timeout', (4, 10))
+
+        if any(secure_mediator in url for secure_mediator in secure_mediators):
+            bbc_i_player_pem = GetBBCiPlayerPemPath()
+            if bbc_i_player_pem:
+                session.cert = bbc_i_player_pem
+                session.mount("https://", SecLevel0SSLAdapter())
+
         try:
             resp = session.request(method, url, *args, **kwargs)
             resp.raise_for_status()

--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -73,7 +73,7 @@ icondir = 'resource://resource.images.iplayerwww/media/'
 cookie_jar = None
 user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:130.0) Gecko/20100101 Firefox/130.0'
 headers = {'User-Agent': user_agent}
-secure_mediators = ['securegate.iplayer.bbc.co.uk', 'ipsecure.stage.bbc.co.uk']
+
 
 if(not os.path.exists(DIR_USERDATA)):
     os.makedirs(DIR_USERDATA)
@@ -380,7 +380,7 @@ def GetBBCiPlayerPemPath():
 
 class SecLevel0SSLAdapter(HTTPAdapter):
     _shared_ssl_context = ssl.create_default_context()
-    # SECLEVEL 1 does not suppress CA_MD_TOO_WEAK on some devices
+    # SECLEVEL=1 does not suppress CA_MD_TOO_WEAK on some devices
     _shared_ssl_context.set_ciphers("DEFAULT:@SECLEVEL=0")
 
     def init_poolmanager(self, connections, maxsize, block=False, **kwargs):
@@ -398,20 +398,36 @@ def OpenRequest(method, url, *args, **kwargs):
         exit_on_error = kwargs.pop('exit_on_error', False)
         kwargs.setdefault('timeout', (4, 10))
 
-        if any(secure_mediator in url for secure_mediator in secure_mediators):
-            bbc_i_player_pem = GetBBCiPlayerPemPath()
-            if bbc_i_player_pem:
-                session.cert = bbc_i_player_pem
-                session.mount("https://", SecLevel0SSLAdapter())
+        if 'securegate.iplayer.bbc.co.uk' in url:
+            bbc_i_player_pem_path = GetBBCiPlayerPemPath()
+            if bbc_i_player_pem_path:
+                session.cert = bbc_i_player_pem_path
+                xbmc.log(f"Using {session.cert} for '{url}'", xbmc.LOGINFO)
 
         try:
             resp = session.request(method, url, *args, **kwargs)
             resp.raise_for_status()
         except requests.exceptions.RequestException as e:
-            xbmc.log(f"'{method}' request to '{url}' failed: {e!r}")
-            if isinstance(e, requests.HTTPError):
-                e = WebRequestError(str(e), e.response)
-            raise e
+            ca_md_too_weak = 'CA_MD_TOO_WEAK'
+            if session.cert and isinstance(e, requests.exceptions.SSLError) and ca_md_too_weak in str(e):
+                xbmc.log(f"Got {ca_md_too_weak} using {session.cert} for '{url}', retrying with SECLEVEL=0",
+                         xbmc.LOGWARNING)
+                try:
+                    session.mount("https://", SecLevel0SSLAdapter())
+                    resp = session.request(method, url, *args, **kwargs)
+                    resp.raise_for_status()
+                except requests.exceptions.RequestException as sec_level_0_exception:
+                    xbmc.log(
+                        f"'{method}' request to '{url}' (after SECLEVEL=0 retry) failed: {sec_level_0_exception!r}")
+                    if isinstance(sec_level_0_exception, requests.HTTPError):
+                        sec_level_0_exception = WebRequestError(str(sec_level_0_exception),
+                                                                sec_level_0_exception.response)
+                    raise sec_level_0_exception
+            else:
+                xbmc.log(f"'{method}' request to '{url}' failed: {e!r}")
+                if isinstance(e, requests.HTTPError):
+                    e = WebRequestError(str(e), e.response)
+                raise e
         try:
             # Refreshed token cookies are set on intermediate requests.
             # Only save if there have been any.

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -1302,10 +1302,11 @@ def AddAvailableStreamsDirectory(name, stream_id, iconimage, description, episod
                      episode_id=episode_id, stream_id=stream_id, resume_time=resume_time, total_time=total_time)
 
 
-def GetURLIfUp(url):
+def GetMediaSelectorJSON(media_selector_url):
     try:
-        OpenURL(url)
-        return url
+        html = OpenURL(media_selector_url)
+        json_data = json.loads(html)
+        return json_data
     except Exception:
         return None
 
@@ -1315,7 +1316,7 @@ def ParseMediaselector(stream_id, live_stream):
     # print("Parsing streams for PID: %s"%stream_id)
     supports_hevc = False
     supports_hevc_uhd = supports_hevc and False
-    media_selector_url = None
+    json_data = None
     # Attempt to load UHD/FHD VOD streams
     if not live_stream and GetBBCiPlayerPemPath():
         secure_url_template = 'https://%s/mediaselector/6/select/version/2.0/vpid/%s/format/json/mediaset/%s/proto/https'
@@ -1325,22 +1326,19 @@ def ParseMediaselector(stream_id, live_stream):
         media_sets.append('iptv-bvq')  # 1080p h264 VOD
         for mediator in secure_mediators:
             for media_set in media_sets:
-                media_selector_url = GetURLIfUp(secure_url_template % (mediator, stream_id, media_set))
-                if media_selector_url:
+                json_data = GetMediaSelectorJSON(secure_url_template % (mediator, stream_id, media_set))
+                if json_data:
                     break
-            if media_selector_url:
+            if json_data:
                 break
     url_template = 'https://open.live.bbc.co.uk/mediaselector/6/select/version/2.0/mediaset/%s/vpid/%s/format/json/cors/1'
     if live_stream and supports_hevc:
         # 1080p HEVC live with multiple audio tracks. It also supports 720p h264 VOD but just use pc for non-live
         media_set = 'iptv-mse'
-        media_selector_url = GetURLIfUp(url_template % (media_set, stream_id))
-    if media_selector_url is None:
+        json_data = GetMediaSelectorJSON(url_template % (media_set, stream_id))
+    if json_data is None:
         media_set = 'pc'  # 720p h264
-        media_selector_url = url_template % (media_set, stream_id)
-    # Open the page with the actual straem information and display the various available streams.
-    html = OpenURL(media_selector_url)
-    json_data = json.loads(html)
+        json_data = GetMediaSelectorJSON(url_template % (media_set, stream_id))
     if json_data:
         # print(json.dumps(json_data, sort_keys=True, indent=2))
         if 'media' in json_data:

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -15,7 +15,7 @@ from operator import itemgetter
 from resources.lib.ipwww_common import (
     translation, AddMenuEntry, OpenURL, OpenRequest, CheckLogin, CreateBaseDirectory,
     GetCookieJar, ParseImageUrl, download_subtitles, GeoBlockedError, WebRequestError,
-    iso_duration_2_seconds, PostJson, strptime, addonid, DeleteUrl, ProgressDlg, GetBBCiPlayerPemPath, secure_mediators)
+    iso_duration_2_seconds, PostJson, strptime, addonid, DeleteUrl, ProgressDlg, GetBBCiPlayerPemPath)
 from resources.lib import ipwww_progress
 
 import xbmc
@@ -1310,35 +1310,34 @@ def GetMediaSelectorJSON(media_selector_url):
     except Exception:
         return None
 
+
 def ParseMediaselector(stream_id, live_stream):
     streams = []
     subtitles = []
     # print("Parsing streams for PID: %s"%stream_id)
     supports_hevc = False
-    supports_hevc_uhd = supports_hevc and False
-    json_data = None
+    media_selector_urls = []
     # Attempt to load UHD/FHD VOD streams
     if not live_stream and GetBBCiPlayerPemPath():
-        secure_url_template = 'https://%s/mediaselector/6/select/version/2.0/vpid/%s/format/json/mediaset/%s/proto/https'
+        secure_url_template = 'https://securegate.iplayer.bbc.co.uk/mediaselector/6/select/version/2.0/vpid/%s/format/json/mediaset/%s/proto/https'
         media_sets = []
-        if supports_hevc_uhd:
+        if supports_hevc:
             media_sets.append('iptv-uhd')  # 2160p hevc VOD
         media_sets.append('iptv-bvq')  # 1080p h264 VOD
-        for mediator in secure_mediators:
-            for media_set in media_sets:
-                json_data = GetMediaSelectorJSON(secure_url_template % (mediator, stream_id, media_set))
-                if json_data:
-                    break
-            if json_data:
-                break
+        for media_set in media_sets:
+            media_selector_urls.append(secure_url_template % (stream_id, media_set))
     url_template = 'https://open.live.bbc.co.uk/mediaselector/6/select/version/2.0/mediaset/%s/vpid/%s/format/json/cors/1'
     if live_stream and supports_hevc:
-        # 1080p HEVC live with multiple audio tracks. It also supports 720p h264 VOD but just use pc for non-live
+        # 1080p HEVC live with audio & audio descriptions tracks. It also supports 720p h264 VOD but just use pc for non-live
         media_set = 'iptv-mse'
-        json_data = GetMediaSelectorJSON(url_template % (media_set, stream_id))
-    if json_data is None:
-        media_set = 'pc'  # 720p h264
-        json_data = GetMediaSelectorJSON(url_template % (media_set, stream_id))
+        media_selector_urls.append(url_template % (media_set, stream_id))
+    media_set = 'pc'  # 720p h264
+    media_selector_urls.append(url_template % (media_set, stream_id))
+    json_data = None
+    for url in media_selector_urls:
+        json_data = GetMediaSelectorJSON(url)
+        if json_data:
+            break
     if json_data:
         # print(json.dumps(json_data, sort_keys=True, indent=2))
         if 'media' in json_data:

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -15,7 +15,7 @@ from operator import itemgetter
 from resources.lib.ipwww_common import (
     translation, AddMenuEntry, OpenURL, OpenRequest, CheckLogin, CreateBaseDirectory,
     GetCookieJar, ParseImageUrl, download_subtitles, GeoBlockedError, WebRequestError,
-    iso_duration_2_seconds, PostJson, strptime, addonid, DeleteUrl, ProgressDlg)
+    iso_duration_2_seconds, PostJson, strptime, addonid, DeleteUrl, ProgressDlg, GetBBCiPlayerPemPath, secure_mediators)
 from resources.lib import ipwww_progress
 
 import xbmc
@@ -1302,13 +1302,44 @@ def AddAvailableStreamsDirectory(name, stream_id, iconimage, description, episod
                      episode_id=episode_id, stream_id=stream_id, resume_time=resume_time, total_time=total_time)
 
 
-def ParseMediaselector(stream_id):
+def GetURLIfUp(url):
+    try:
+        OpenURL(url)
+        return url
+    except Exception:
+        return None
+
+def ParseMediaselector(stream_id, live_stream):
     streams = []
     subtitles = []
     # print("Parsing streams for PID: %s"%stream_id)
-    # Open the page with the actual strem information and display the various available streams.
-    NEW_URL = 'https://open.live.bbc.co.uk/mediaselector/6/select/version/2.0/mediaset/pc/vpid/%s/format/json/cors/1' % stream_id 
-    html = OpenURL(NEW_URL)
+    supports_hevc = False
+    supports_hevc_uhd = supports_hevc and False
+    media_selector_url = None
+    # Attempt to load UHD/FHD VOD streams
+    if not live_stream and GetBBCiPlayerPemPath():
+        secure_url_template = 'https://%s/mediaselector/6/select/version/2.0/vpid/%s/format/json/mediaset/%s/proto/https'
+        media_sets = []
+        if supports_hevc_uhd:
+            media_sets.append('iptv-uhd')  # 2160p hevc VOD
+        media_sets.append('iptv-bvq')  # 1080p h264 VOD
+        for mediator in secure_mediators:
+            for media_set in media_sets:
+                media_selector_url = GetURLIfUp(secure_url_template % (mediator, stream_id, media_set))
+                if media_selector_url:
+                    break
+            if media_selector_url:
+                break
+    url_template = 'https://open.live.bbc.co.uk/mediaselector/6/select/version/2.0/mediaset/%s/vpid/%s/format/json/cors/1'
+    if live_stream and supports_hevc:
+        # 1080p HEVC live with multiple audio tracks. It also supports 720p h264 VOD but just use pc for non-live
+        media_set = 'iptv-mse'
+        media_selector_url = GetURLIfUp(url_template % (media_set, stream_id))
+    if media_selector_url is None:
+        media_set = 'pc'  # 720p h264
+        media_selector_url = url_template % (media_set, stream_id)
+    # Open the page with the actual straem information and display the various available streams.
+    html = OpenURL(media_selector_url)
     json_data = json.loads(html)
     if json_data:
         # print(json.dumps(json_data, sort_keys=True, indent=2))
@@ -1364,8 +1395,8 @@ def ParseDASHStreams(stream_id):
     streams = []
     subtitles = []
     # print "Parsing streams for PID: %s"%stream_id
-    mediaselector = ParseMediaselector(stream_id)
-    # Open the page with the actual strem information and display the various available streams.
+    mediaselector = ParseMediaselector(stream_id, False)
+    # Open the page with the actual stream information and display the various available streams.
     source = int(ADDON.getSetting('catchup_source'))
     for url, protocol, supplier, transfer_format in mediaselector[0]:
         tmp_sup = 0
@@ -1407,7 +1438,7 @@ def ParseDASHStreams(stream_id):
 
 def ParseLiveDASHStreams(channelname):
     streams = []
-    mediaselector = ParseMediaselector(channelname)
+    mediaselector = ParseMediaselector(channelname, True)
     # print mediaselector
     for provider_url, protocol, provider_name, transfer_format in mediaselector[0]:
         if transfer_format == 'dash':


### PR DESCRIPTION
- 2160p/1080p vod streams requires bbciplayer.pem (See: https://po-ru.com/2010/06/07/device-discrimination-on-the-internet) to be placed in either:
  - `addons/plugin.video.iplayerwww/bbciplayer.pem`
  - `userdata/addon_data/plugin.video.iplayerwww/bbciplayer.pem`
  - Older pem files will error with `CA_MD_TOO_WEAK` but still work with `SECLEVEL=0`
- 1080p HEVC live streams are used if available closes #397
- Disabled by default to reduce user support