### PR TITLE
Fix 'channels hightlights' remained hidden

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -126,7 +126,7 @@
                                     <default>true</default>
                                     <control type="toggle"/>
                                 </setting>
-                                <setting id="menu_video_channel_highlighty" type="boolean" label="30512" help="">
+                                <setting id="menu_video_channel_highlights" type="boolean" label="30512" help="">
                                     <level>0</level>
                                     <default>true</default>
                                     <control type="toggle"/>


### PR DESCRIPTION
Due to a typo the menu entry 'channel highlights' remained hidden when enabled in settings.