### PR TITLE
Ensure the user is logged out, despite network errors.

### DIFF
--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -312,7 +312,10 @@ def SignOutBBCiD():
     let's be nice and inform the Beeb as well.
     """
     sign_out_url="https://account.bbc.com/signout"
-    OpenURL(sign_out_url)
+    try:
+        OpenURL(sign_out_url)
+    except:
+        pass
     cookie_jar.clear()
     cookie_jar.save()
     xbmcgui.Dialog().notification(translation(30326), translation(30309))


### PR DESCRIPTION
Peviously, sign out failed when reporting back to the BBC failed, while that's not a requirement. User's should be able to clear their account without a connection to the BBC.