### PR TITLE
Detect geo block from HTTP Status.

### DIFF
--- a/resources/lib/ipwww_common.py
+++ b/resources/lib/ipwww_common.py
@@ -34,7 +34,13 @@ class IpwwwError(Exception):
 
 
 class GeoBlockedError(IpwwwError):
-    pass
+    def __init__(self, url):
+        super().__init__()
+        self.url = url
+    def __str__(self):
+        return translation(30401)
+    def __repr__(self):
+        return ''.join(("GeoBlockedError for url '",  self.url, '."'))
 
 
 class WebRequestError(IpwwwError):
@@ -380,7 +386,10 @@ def OpenRequest(method, url, *args, **kwargs):
         except requests.exceptions.RequestException as e:
             xbmc.log(f"'{method}' request to '{url}' failed: {e!r}")
             if isinstance(e, requests.HTTPError):
-                e = WebRequestError(str(e), e.response)
+                if e.response.status_code == 403:
+                    e = GeoBlockedError(url)
+                else:
+                    e = WebRequestError(str(e), e.response)
             raise e
         try:
             # Refreshed token cookies are set on intermediate requests.

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -1210,12 +1210,11 @@ def ListRecommendations(item_id=None):
 def PlayStream(name, url, iconimage, description='', subtitles_url='', episode_id=None, stream_id=None, replay_chan_id=''):
     if iconimage == '':
         iconimage = 'DefaultVideo.png'
-    html = OpenURL(url)
-    check_geo = re.search(
-        '<H1>Access Denied</H1>', html)
-    if check_geo or not html:
-        # print "Geoblock detected, raising error message"
-        raise GeoBlockedError(translation(30401))
+
+    # Check geo-block. It's quite impossible now to get here without having run into a geo-block
+    # earlier, but left in just in case someone find a way.
+    OpenURL(url)
+
     liz = xbmcgui.ListItem(name)
     liz.setArt({'icon':'DefaultVideo.png', 'thumb':iconimage})
     liz.setInfo(type='Video', infoLabels={'Title': name})
@@ -1347,9 +1346,9 @@ def ParseMediaselector(stream_id):
                                 if protocol == 'https':
                                     streams.append((href, protocol, supplier, transfer_format))
         elif 'result' in json_data:
+            # MediaSelector will probably already have returned HTTP status 403, but keep this check just to be sure.
             if json_data['result'] == 'geolocation':
-                # print "Geoblock detected, raising error message"
-                raise GeoBlockedError(translation(30401))
+                raise GeoBlockedError()
     # print("Found streams:")
     # print(streams)
     # print(subtitles)


### PR DESCRIPTION
Geblocked reponses no longer include the html text we try to find. Requests now return HTTP status 403 when outside the UK. On one systems I use most pages are geoblocked, while on others only playing is blocked.

All 403 reponses will now raise a GeoBlockedError