### PR TITLE
IPTV Manager integration.

### DIFF
--- a/default.py
+++ b/default.py
@@ -100,7 +100,7 @@ try:
     if mode == 1:
         Common.KidsMode()
 
-    elif mode is None or url is None or len(url) < 1:
+    elif mode is None:
         Common.CreateBaseDirectory(content_type)
 
     # Modes 101-119 will create a main directory menu entry
@@ -250,6 +250,15 @@ try:
 
     elif mode == 302:
         Video.RemoveFavourite(episode_id)
+
+    # Modes 401 - 499: Called as script, e.g. IPTV manager requesting channels
+    elif mode == 401:
+        from resources.lib.ipwww_iptv import channels
+        channels(params['port'])
+
+    elif mode == 402:
+        from resources.lib.ipwww_iptv import epg
+        epg(params['port'])
 
 except Exception as err:
     import traceback

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -32,6 +32,10 @@ msgctxt "#30103"
 msgid "Common settings"
 msgstr ""
 
+msgctxt "#30104"
+msgid "TV integration"
+msgstr ""
+
 msgctxt "#30110"
 msgid "Play Signed programmes when available"
 msgstr ""
@@ -190,6 +194,34 @@ msgstr ""
 
 msgctxt "#30240"
 msgid "Subtitle CDN source"
+msgstr ""
+
+msgctxt "#30250"
+msgid "IPTV Manager integration"
+msgstr ""
+
+msgctxt "#30251"
+msgid "Install 'IPTV manager' addon"
+msgstr ""
+
+msgctxt "#30252"
+msgid "Enable IPTV Manager integration"
+msgstr ""
+
+msgctxt "#30253"
+msgid "Select TV channels"
+msgstr ""
+
+msgctxt "#30254"
+msgid "Select radio stations"
+msgstr ""
+
+msgctxt "#30258"
+msgid "Go to IPTV manager settings..."
+msgstr ""
+
+msgctxt "#30259"
+msgid "It may take a few hours before these settings take effect.\nTo force an update, select 'Refresh channels and guide now' in IPTV Manager's settings and select 'clear data' in section 'Guide' of Kodi's 'PVR & Live TV' settings."
 msgstr ""
 
 msgctxt "#30300"

--- a/resources/lib/ipwww_iptv.py
+++ b/resources/lib/ipwww_iptv.py
@@ -1,0 +1,162 @@
+import socket
+import json
+from datetime import datetime, timedelta, timezone
+
+import xbmc
+
+from resources.lib.ipwww_video import (
+    channel_list as tv_channel_list,
+    SelectSynopsis,
+    SelectImage)
+
+from resources.lib.ipwww_common import (
+    addonid,
+    utf8_quote_plus,
+    ADDON,
+    OpenRequest)
+
+
+# IPTVManager class from https://github.com/add-ons/service.iptv.manager/wiki/Integration
+class IPTVManager:
+    """Interface to IPTV Manager"""
+
+    def __init__(self, port):
+        """Initialize IPTV Manager object"""
+        self.port = port
+
+    def via_socket(func):
+        """Send the output of the wrapped function to socket"""
+
+        def send(self):
+            """Decorator to send over a socket"""
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.connect(('127.0.0.1', self.port))
+            try:
+                sock.sendall(json.dumps(func(self)).encode())
+            finally:
+                sock.close()
+
+        return send
+
+    @via_socket
+    def send_channels(self):
+        """Return JSON-STREAMS formatted python datastructure to IPTV Manager"""
+        tv_chans = enabled_channels(ADDON.getSetting('iptv.tv_channels').split(';'),
+                                    tv_channel_list)
+        return {'version': 1, 'streams': tv_chans}
+
+    @via_socket
+    def send_epg(self):
+        """Return JSON-EPG formatted python data structure to IPTV Manager"""
+        guide = tv_epg()
+        return {'version': 1, 'epg': guide}
+
+
+def channels(port):
+    xbmc.log(f"[ipwww_iptv] Sending IPTV channels list.", xbmc.LOGDEBUG)
+    try:
+        IPTVManager(int(port)).send_channels()
+    except Exception as err:
+        # Catch all errors to prevent default() showing an error message
+        xbmc.log(f"[ipwww_iptv] Error in iptvmanager.channels: {err!r}.", xbmc.LOGERROR)
+
+
+def epg(port):
+    try:
+        IPTVManager(int(port)).send_epg()
+    except Exception as err:
+        # Catch all errors to prevent default() showing an error message
+        xbmc.log(f"[ipwww_iptv] Error in iptvmanager.epg: {err!r}.", xbmc.LOGDEBUG)
+
+
+def enabled_channels(enabled_ids, all_channels):
+    mode = '203'
+    # BBC Two England has the same channel ID as BBC TWO (HD) and is filtered out to
+    # prevent both appearing in the TV list when BBC Two is enabled.
+    enabled_chans = [chan for chan in all_channels if chan[0] in enabled_ids and chan[1] != 'BBC Two England']
+    chan_list = []
+    for chan in enabled_chans:
+        chan_id = chan[0]
+        chan_name = chan[1]
+        iconimage = f'resource://resource.images.iplayerwww/media/{chan_id}.png'
+        url = ''.join((
+            'plugin://', addonid,
+            '?url=', utf8_quote_plus(chan_id),
+            '&mode=', mode,
+            '&name=', utf8_quote_plus(chan_name),
+            '&iconimage', utf8_quote_plus(iconimage)
+        ))
+        chan_list.append(
+            {'id': 'ipwww.' + chan_id,
+             'name': chan_name,
+             'logo': iconimage,
+             'stream': url,
+             'radio': False}
+        )
+    return chan_list
+
+
+def tv_epg():
+    """Return the full TV EPG from 7 days back to 7 days ahead.
+
+    """
+    utc_now = datetime.now(timezone.utc)
+    week_back = utc_now - timedelta(days=7)
+    enabled_chan_ids = ADDON.getSetting('iptv.tv_channels').split(';')
+    items_per_page = 200        # max allowed number
+    tv_guide = {}
+    xbmc.log(f"[ipwww_iptv] Creating IPTV EPG for channels {enabled_chan_ids}.", xbmc.LOGDEBUG)
+
+    for chan_id in enabled_chan_ids:
+        # There are no schedules specifically for HD channels.
+        if chan_id == 'bbc_one_hd':
+            schedule_chan_id = 'bbc_one_london'
+        elif chan_id.endswith('_hd'):
+            schedule_chan_id = chan_id[:-3]
+        elif chan_id:
+            schedule_chan_id = chan_id
+        else:
+            continue
+
+        progr_list = []
+        # Range is just to ensure we break out of the loop at some point if something goes
+        # wrong with counting received items. Schedules should never have more than 2000
+        # items in 2 weeks.
+        for pagenr in range(1, 10):
+            url = ''.join(('https://ibl.api.bbc.co.uk/ibl/v1/channels/',
+                           schedule_chan_id,
+                           '/broadcasts?per_page=',
+                           str(items_per_page),
+                           '&page=',
+                           str(pagenr),
+                           '&from_date=',
+                           week_back.strftime('%Y-%m-%dT%H:%M')))
+            resp_data = json.loads(OpenRequest('get', url))
+            schedule_list = resp_data['broadcasts']['elements']
+            for progr in schedule_list:
+                episode = progr['episode']
+                categories = episode.get('categories')
+                if episode.get('status') == 'available':
+                    url = 'https://www.bbc.co.uk/iplayer/episode/' + episode['id']
+                    stream = ''.join(('plugin://',
+                                      addonid,
+                                      '?url=', utf8_quote_plus(url),
+                                      '&mode=202'))  # &iconimage=&description=
+                else:
+                    stream = None
+                progr_list.append({
+                    'start': progr['scheduled_start'],
+                    'stop': progr['scheduled_end'],
+                    'title': episode.get('title'),
+                    'description': SelectSynopsis(episode.get('synopses')),
+                    'subtitle': episode.get('editorial_subtitle') or episode.get('subtitle'),
+                    'genre': categories[0] if categories else None,
+                    'image': SelectImage(episode.get('images')),
+                    'date': episode.get('release_date_time'),
+                    'stream': stream
+                })
+            if pagenr * items_per_page >= resp_data['broadcasts']['count']:
+                break
+
+        tv_guide['ipwww.' + chan_id] = progr_list
+    return tv_guide

--- a/resources/lib/ipwww_video.py
+++ b/resources/lib/ipwww_video.py
@@ -129,9 +129,7 @@ def AddAvailableUHDTrialItem(name, channelname):
     PlayStream(name, url, "", "", "")
 
 
-# ListLive creates menu entries for all live channels.
-def ListLive():
-    channel_list = [
+channel_list = [
         ('bbc_one_hd',                       'BBC One',                  'bbc_one_london'),
         ('bbc_two_england',                  'BBC Two',                  'bbc_two_england'),
         ('bbc_three_hd',                     'BBC Three',                'bbc_three'),
@@ -166,7 +164,12 @@ def ListLive():
         ('bbc_one_west_midlands',            'BBC One West Midlands',    'bbc_one_london'),
         ('bbc_one_yorks',                    'BBC One Yorks',            'bbc_one_london'),
     ]
+
+
+# ListLive creates menu entries for all live channels.
+def ListLive():
     from urllib.parse import urlencode
+
     schedules = GetSchedules(channel_list)
     for id, name, schedule_chan_id in channel_list:
         now_on, schedule = schedules.get(schedule_chan_id, ('', ''))

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -327,5 +327,98 @@
                                 </setting>
 			</group>
 		</category>
+        <category id ="iptv" label="30104" help="">
+           <group id="1" label="30250">
+                                <setting id="install_iptvmanager" label="30251" type="action" help="">
+                                    <level>0</level>
+                                    <data>InstallAddon(service.iptv.manager)</data>
+                                    <control type="button" format="action">
+                                        <close>true</close>
+                                    </control>
+                                    <dependencies>
+                                        <dependency type="visible" on="property" name="infobool" operator="!is">System.HasAddon(service.iptv.manager)</dependency>
+                                    </dependencies>
+                                </setting>
+                                <setting id="iptv.enabled" label="30252" type="boolean" help="30259">
+                                    <level>0</level>
+                                    <default>true</default>
+                                    <control type="toggle"/>
+                                    <dependencies>
+                                        <dependency type="visible" on="property" name="infobool">System.HasAddon(service.iptv.manager)</dependency>
+                                    </dependencies>
+                                </setting>
+                                <setting id="iptv.tv_channels" type="list[string]" label="30253" help="30255" parent="iptv.enabled">
+                                    <level>0</level>
+                                    <default>bbc_one_hd;bbc_two_england;bbc_three_hd;bbc_four_hd</default>
+                                    <constraints>
+                                        <options>
+                                            <option label="BBC One">bbc_one_hd</option>
+                                            <option label="BBC Two">bbc_two_england</option>
+                                            <option label="BBC Three">bbc_three_hd</option>
+                                            <option label="BBC Four">bbc_four_hd</option>
+                                            <option label="CBBC">cbbc_hd</option>
+                                            <option label="CBeebies">cbeebies_hd</option>
+                                            <option label="BBC News Channel">bbc_news24</option>
+                                            <option label="BBC Parliament">bbc_parliament</option>
+                                            <option label="Alba">bbc_alba</option>
+                                            <option label="BBC Scotland">bbc_scotland_hd</option>
+                                            <option label="S4C">s4cpbs</option>
+                                            <option label="BBC One London">bbc_one_london</option>
+                                            <option label="BBC One Scotland">bbc_one_scotland_hd</option>
+                                            <option label="BBC One Northern Ireland">bbc_one_northern_ireland_hd</option>
+                                            <option label="BBC One Wales">bbc_one_wales_hd</option>
+                                            <option label="BBC Two Scotland">bbc_two_scotland</option>
+                                            <option label="BBC Two Northern Ireland">bbc_two_northern_ireland_digital</option>
+                                            <option label="BBC Two Wales">bbc_two_wales_digital</option>
+                                            <option label="BBC One Cambridge">bbc_one_cambridge</option>
+                                            <option label="BBC One Channel Islands">bbc_one_channel_islands</option>
+                                            <option label="BBC One East">bbc_one_east</option>
+                                            <option label="BBC One East Midlands">bbc_one_east_midlands</option>
+                                            <option label="BBC One East Yorkshire">bbc_one_east_yorkshire</option>
+                                            <option label="BBC One North East">bbc_one_north_east</option>
+                                            <option label="BBC One North West">bbc_one_north_west</option>
+                                            <option label="BBC One Oxford">bbc_one_oxford</option>
+                                            <option label="BBC One South">bbc_one_south</option>
+                                            <option label="BBC One South East">bbc_one_south_east</option>
+                                            <option label="BBC One South West">bbc_one_south_west</option>
+                                            <option label="BBC One West">bbc_one_west</option>
+                                            <option label="BBC One West Midlands">bbc_one_west_midlands</option>
+                                            <option label="BBC One Yorks">bbc_one_yorks</option>
+                                        </options>
+                                        <allowempty>true</allowempty>
+                                        <delimiter>;</delimiter>
+                                    </constraints>
+                                    <dependencies>
+                                        <dependency type="enable" setting="iptv.enabled">true</dependency>
+                                        <dependency type="visible" on="property" name="infobool">System.HasAddon(service.iptv.manager)</dependency>
+                                    </dependencies>
+                                    <control type="list" format="string">
+                                        <heading>30253</heading>
+                                        <multiselect>true</multiselect>
+                                        <hidevalue>true</hidevalue>
+                                    </control>
+                                </setting>
+                                <setting id="iptvmanager_settings" label="30258" type="action" help="" parent="iptv.enabled">
+                                    <data>Addon.OpenSettings(service.iptv.manager)</data>
+                                    <dependencies>
+                                        <dependency type="enable" setting="iptv.enabled">true</dependency>
+                                        <dependency type="visible" on="property" name="infobool">System.HasAddon(service.iptv.manager)</dependency>
+                                    </dependencies>
+                                    <control type="button" format="action">
+                                        <close>true</close>
+                                    </control>
+                                </setting>
+                                <setting id="iptv.channels_uri" label="" type="string" help="">
+                                    <default>plugin://plugin.video.iplayerwww?mode=401</default>
+                                    <visible>false</visible>
+                                    <control type="edit" format="string" />
+                                </setting>
+                                <setting id="iptv.epg_uri" label="" type="string" help="">
+                                    <default>plugin://plugin.video.iplayerwww?mode=402</default>
+                                    <visible>false</visible>
+                                    <control type="edit" format="string" />
+                                </setting>
+            </group>
+        </category>
 	</section>
 </settings>


### PR DESCRIPTION
Enable integration of BBC live channels into Kodi's TV section with the aid of the add-ons IPTV Manager (or IPTV Merge) and IPTV Simple.

Allows BCC live channels to appear in Kodi's TV section, show EPG data in TV/Guide and allow past programmes to play as VOD from the Guide, whenever the programme is available as VOD.

For this to work, users must have 'IPTV Simple Client' enabled as PVR Client addon in Kodi, and have installed the program add-on 'IPTV Manager'. 'IPTV Merge' should work as well, as an alternative to 'IPTV Manager'.

There is a new section in settings to disable IPTV integration and select the TV channels to include.
By default the four main BBC channels are enabled, so users of iptvsimple/IPTV manager should automatically see these channels appear in their TV list.
Note:
After the add-on update, or after enabling channels in iplayerwww's settings, changes won't appear in Kodi's TV section  until both IPTV Manager and Kodi  PVR&Live TV have updated the channel list and EPG. Which can take a few hours, depending on their settings.


**More info:**
[IPTV Merge](https://www.matthuisman.nz/2019/02/iptv-merge-kodi-add-on.html)
[IPTV Manager](https://github.com/add-ons/service.iptv.manager/wiki)